### PR TITLE
Add security monitoring to GitHub-hosted runner for e2e-tests.yaml

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -22,6 +22,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    # Hardens the GitHub-hosted runner (Ubuntu VM) 
+    - name: Harden Runner
+      uses: step-security/harden-runner@v1
+      with:
+        egress-policy: audit
+        
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout repo
       uses: actions/checkout@v2


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 

/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

This pull request adds [step-security/harden-runner](https://github.com/step-security/harden-runner) GitHub Action to the `e2e-tests.yaml` workflow. This GitHub Action adds security monitoring and policy-based controls to the GitHub-hosted runner (Ubuntu VM) before other steps run. 

In the current configuration `egress-policy: audit`, it will monitor the outbound traffic, and display a report of outbound traffic ([report](https://app.stepsecurity.io/github/varunsh-coder/devspace/actions/runs/1688500767) when run on a fork). After it runs a couple of times, based on the outbound traffic observed, I can create another PR to restrict outbound traffic to only expected endpoints. 

Running this in end-to-end tests can help discover unexpected outbound traffic, which may be due to a compromised/ hijacked dependency. 

**Please provide a short message that should be published in the DevSpace release notes**
Added security monitoring to hosted runner for e2e-tests.yaml

**What else do we need to know?** 
@LukasGentele as discussed offline, creating this PR to pilot `step-security/harden-runner`. Appreciate feedback/ suggestions for improvement. Thanks!