### PR TITLE
docs: add documentation page for inline manifests. Fix ENG-652

### DIFF
--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/inline_manifests.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/inline_manifests.mdx
@@ -1,0 +1,14 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `inlineManifest` <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-inline-manifests}
+
+InlineManifest is a block containing the yaml manifest that will be deployed by DevSpace using kubectl
+or kustomize
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl_reference.mdx
@@ -1,11 +1,15 @@
 
 import PartialManifests from "./kubectl/manifests.mdx"
+import PartialInlineManifests from "./kubectl/inline_manifests.mdx"
 import PartialApplyArgs from "./kubectl/applyArgs.mdx"
 import PartialCreateArgs from "./kubectl/createArgs.mdx"
 import PartialKubectlBinaryPath from "./kubectl/kubectlBinaryPath.mdx"
 import PartialGroupkustomize from "./kubectl/group_kustomize.mdx"
 
 <PartialManifests />
+
+
+<PartialInlineManifests />
 
 
 <PartialApplyArgs />

--- a/docs/pages/configuration/deployments/kubectl/README.mdx
+++ b/docs/pages/configuration/deployments/kubectl/README.mdx
@@ -8,6 +8,7 @@ import ConfigPartial from '../../_partials/v2beta1/deployments/kubectl.mdx'
 
 DevSpace supports two types of deployments aside from Helm charts:
 - [`Kubernetes manifests`](./manifests.mdx) (think `kubectl apply -f manifest.yaml`)
+- [`Kubernetes inline manifests`](./inline_manifests.mdx) (think `kubectl apply -f manifest.yaml`)
 - [`Kustomizations`](./kustomizations.mdx) (think `kubectl apply -k kustomization/`)
 
 

--- a/docs/pages/configuration/deployments/kubectl/inline_manifests.mdx
+++ b/docs/pages/configuration/deployments/kubectl/inline_manifests.mdx
@@ -1,0 +1,118 @@
+---
+title: Deploy Kubernetes Inline Manifests
+sidebar_label: InlineManifests
+---
+
+import FragmentKubectlApplyArgs from '../../../_partials/kubectl-options-applyArgs.mdx';
+import FragmentKubectlBinaryPath from '../../../_partials/kubectl-options-binaryPath.mdx';
+import FragmentKubectlKustomize from '../../../_partials/kubectl-kustomize.mdx';
+import FragmentKustomizeKustomizeArgs from '../../../_partials/kustomize-options-kustomizeArgs.mdx';
+import FragmentUpdateImageTags from '../../../_partials/kubectl-updateImageTags.mdx';
+
+To deploy Kubernetes using inline manifests with `kubectl apply`, you need to configure them within the `deployments` section of the `devspace.yaml`.
+
+
+## Example
+```yaml title=devspace.yaml
+pipelines:
+  dev: 
+    run: |
+      create_deployments backend
+      create_deployments frontend
+deployments:
+  backend:
+    kubectl:
+      inlineManifest:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: busybox-sleep
+        spec:
+          containers:
+          - name: busybox
+            image: busybox:1.28
+            args:
+            - sleep
+            - "1000000"
+  frontend:
+    kubectl:
+      manifests:
+      - frontend/manifest.yaml
+```
+
+The above example will be executed during the deployment process as follows:
+```bash
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-sleep
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.28
+    args:
+    - sleep
+    - "1000000"
+EOF
+```
+
+
+## Update Image Tags
+
+<FragmentUpdateImageTags/>
+
+
+## `kubectl` Binary
+Deployments with `kubectl` require `kubectl` to be installed. If the `kubectl` binary cannot be found within the `$PATH` variable and it is not specified by specifying the [`kubectlBinaryPath` option](./README.mdx#deployments-kubectl-kubectlBinaryPath), DevSpace will download the `kubectl` binary into the `$HOME/.devspace/bin` folder.
+
+
+
+## Extra Arguments
+When deploying manifests via `kubectl`, DevSpace can pass additional arguments and flags to the `kubectl` commands used for the deployment process.
+
+### Args For `kubectl create`
+The `createArgs` option expects an array of strings stating additional arguments (and flags) that should be used when calling `kubectl create`.
+
+#### Example: Custom Kubectl Args & Flags
+```yaml
+deployments:
+  backend:
+    kubectl:
+      inlineManifest:
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          name: busybox-sleep
+        spec:
+          containers:
+          - name: busybox
+            image: busybox:1.28
+            args:
+            - sleep
+            - "1000000"
+      createArgs:
+      - "--recursive"
+```
+**Explanation:**  
+Deploying the above example would roughly be equivalent to this command:
+```bash
+cat <<EOF | kubectl create --dry-run --output yaml --validate=false --recursive -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox-sleep
+spec:
+  containers:
+  - name: busybox
+    image: busybox:1.28
+    args:
+    - sleep
+    - "1000000"
+EOF
+```
+
+
+### Args For `kubectl apply`
+
+<FragmentKubectlApplyArgs/>

--- a/docs/schemas/config-openapi.json
+++ b/docs/schemas/config-openapi.json
@@ -1168,6 +1168,10 @@
                 "type": "array",
                 "description": "Manifests is a list of files or folders that will be deployed by DevSpace using kubectl\nor kustomize"
               },
+              "inlineManifest": {
+                "type": "string",
+                "description": "InlineManifest is a block containing the yaml that  will be deployed by DevSpace using kubectl"
+              },
               "applyArgs": {
                 "items": {
                   "type": "string"

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -90,6 +90,7 @@ module.exports = {
               link: { type: 'doc', id: 'configuration/deployments/kubectl/README' },
               items: [
                 'configuration/deployments/kubectl/manifests',
+                'configuration/deployments/kubectl/inline_manifests',
                 'configuration/deployments/kubectl/kustomizations',
               ],
             },


### PR DESCRIPTION
Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation


**Please provide a short message that should be published in the DevSpace release notes**
Adding documentation page for the new Inline Manifest feature
