### PR TITLE
docs: add back runtime variables page from 5.x. Fix ENG-878

### DIFF
--- a/docs/pages/configuration/runtime-variables.mdx
+++ b/docs/pages/configuration/runtime-variables.mdx
@@ -1,0 +1,174 @@
+---
+title: Runtime Variables
+sidebar_label: ${runtime.variables}
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Runtime variables are special variables that are only available in certain config areas and are filled during runtime. Those variables are useful to access certain runtime information, such as hook output or image tags.
+
+<Tabs
+defaultValue="var1"
+values={[
+    { label: 'Separate Repo & Tag', value: 'var1', },
+    { label: 'Customize Helm Values', value: 'var2', },
+    { label: 'Customize Kubernetes Manifests', value: 'var3', },
+    { label: 'Dependency', value: 'var4', },
+]
+}>
+<TabItem value="var1">
+
+```yaml
+images:
+  app:
+    image: registry.url/repo/image
+deployments:
+  backend:
+    helm:
+      chart:
+        name: chart-name
+        repo: https://my-charts.company.tld/
+      values:
+        # If registry.url/repo/image was found under images as well, will be
+        # rewritten to registry.url/repo/image:generated_tag
+        imageWithTag: registry.url/repo/image
+        # If registry.url/repo/image was found under images.app as well, will be
+        # rewritten to registry.url/repo/image
+        imageWithoutTag: ${runtime.images.app.image}
+        # If registry.url/repo/image was found under images.app as well, will be
+        # rewritten to generated_tag
+        onlyTag: ${runtime.images.app.tag}
+```
+
+</TabItem>
+<TabItem value="var2">
+
+```yaml
+images:
+  app:
+    image: myuser/image
+hooks:
+  - name: "image-digest"
+    events: ["after:build:app"]
+    command: |
+      # This command prints the image digest
+      echo $(docker inspect ${runtime.images.app.image}:${runtime.images.app.tag} --format='{{index .RepoDigests 0}}' | cut -d'@' -f2)
+deployments:
+  checkout:
+    helm:
+      chart:
+        name: ./kubernetes/helm/app
+      values:
+        app:
+          image:
+            digest: ${runtime.hooks.image-digest.stdout}
+```
+
+</TabItem>
+<TabItem value="var3">
+
+```yaml
+
+images:
+  your-image:
+    image: localhost:5000/my/customalpine
+    kaniko:
+      insecure: true
+      skipPullSecretMount: true
+
+deployments:
+  quickstart:
+    kubectl:
+      inlineManifest: |-
+        kind: Deployment
+        apiVersion: apps/v1
+        metadata:
+          name: devspace
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app.kubernetes.io/component: default
+              app.kubernetes.io/name: devspace-app
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/component: default
+                app.kubernetes.io/name: devspace-app
+            spec:
+              containers:
+                - name: default
+                  # The correct image tag will be inserted during devspace dev / devspace deploy
+                  image: ${runtime.images.your-image}
+
+```
+
+</TabItem>
+<TabItem value="var4">
+
+```yaml
+dependencies:
+  dep1:
+    source:
+      path: dep1
+dev:
+  my-dev:
+    imageSelector: ${runtime.dependencies.dep1.images.image1}
+    terminal: {}
+```
+
+</TabItem>
+</Tabs>
+    
+Runtime variables can be used in the following DevSpace config sections:
+
+```
+/images/*/build/custom/command
+/images/*/build/custom/commands/*/command
+/images/*/build/custom/args/**
+/images/*/build/custom/appendArgs/**
+/deployments/*/helm/values/**
+/deployments/*/kubectl/inlineManifest/**
+/hooks/*/command
+/hooks/*/args/*
+/hooks/*/container/imageSelector
+/dev/*/imageSelector
+/dev/*/replaceImage
+/dev/*/devImage
+/dev/*/containers/*/replaceImage
+/dev/*/containers/*/devImage
+/pipelines/*
+/pipelines/*/flags/**
+/pipelines/*/run
+/commands/*
+/commands/*/command
+/functions/**
+/imports/**
+```
+
+:::info
+If you try to use a runtime variable in a different config section, DevSpace will print an error and fail.
+:::
+
+The following runtime variables exist:
+
+- **`runtime.images.IMAGE_NAME`**: Holds the image name (defined at `images.*.image`) and tag that was built by DevSpace (e.g. `my-repo.com/image:latest`)
+- **`runtime.images.IMAGE_NAME.tag`**: Holds the image tag that was built by DevSpace (e.g. `asdHTR` or `latest`)
+- **`runtime.images.IMAGE_NAME.image`**: Holds the image name (defined at `images.*.image`) that was used for building (e.g. `my-repo.com/image`)
+
+## Accessing runtime variables of dependencies
+
+You can also access runtime variables of an executed dependency by using `runtime.dependencies.DEPENDENCY_NAME...`. 
+
+For example:
+```yaml
+dependencies:
+  dep1:
+    source:
+      path: dep1
+dev:
+  my-dev:
+    imageSelector: ${runtime.dependencies.dep1.images.image1}
+    terminal: {}
+```

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -171,6 +171,7 @@ module.exports = {
         'configuration/localRegistry/README',
         'configuration/require/README',
         'configuration/variables',
+        'configuration/runtime-variables',
         'configuration/expressions',
       ],
     },

--- a/pkg/devspace/analyze/analyze_test.go
+++ b/pkg/devspace/analyze/analyze_test.go
@@ -64,8 +64,10 @@ type createReportTestCase struct {
 	expectedReport []*ReportItem
 }
 
-/*Part of this function is untestable right now because the helper function events uses the RestClient of the KubeClient.
-The fake client returns nil. Therefore it's not possible to let events return problems.*/
+/*
+Part of this function is untestable right now because the helper function events uses the RestClient of the KubeClient.
+The fake client returns nil. Therefore it's not possible to let events return problems.
+*/
 func TestCreateReport(t *testing.T) {
 	testCases := []createReportTestCase{
 		{

--- a/pkg/devspace/config/loader/variable/runtime/runtime_variable.go
+++ b/pkg/devspace/config/loader/variable/runtime/runtime_variable.go
@@ -17,6 +17,7 @@ var Locations = []string{
 	"/images/*/build/custom/args/**",
 	"/images/*/build/custom/appendArgs/**",
 	"/deployments/*/helm/values/**",
+	"/deployments/*/kubectl/inlineManifest/**",
 	"/hooks/*/command",
 	"/hooks/*/args/*",
 	"/hooks/*/container/imageSelector",

--- a/pkg/devspace/config/versions/v1beta11/schema.go
+++ b/pkg/devspace/config/versions/v1beta11/schema.go
@@ -671,7 +671,7 @@ type ChartConfig struct {
 	Git      *GitSource `yaml:"git,omitempty" json:"git,omitempty"`
 }
 
-//GitSource defines the git repository options
+// GitSource defines the git repository options
 type GitSource struct {
 	URL       string   `yaml:"url,omitempty" json:"url,omitempty"`
 	CloneArgs []string `yaml:"cloneArgs,omitempty" json:"cloneArgs,omitempty"`

--- a/pkg/devspace/kubectl/portforward/portforward.go
+++ b/pkg/devspace/kubectl/portforward/portforward.go
@@ -65,18 +65,18 @@ type ForwardedPort struct {
 }
 
 /*
-	valid port specifications:
+valid port specifications:
 
-	5000
-	- forwards from localhost:5000 to pod:5000
+5000
+- forwards from localhost:5000 to pod:5000
 
-	8888:5000
-	- forwards from localhost:8888 to pod:5000
+8888:5000
+- forwards from localhost:8888 to pod:5000
 
-	0:5000
-	:5000
-	- selects a random available local port,
-	  forwards from localhost:<random port> to pod:5000
+0:5000
+:5000
+  - selects a random available local port,
+    forwards from localhost:<random port> to pod:5000
 */
 func ParsePorts(ports []string) ([]ForwardedPort, error) {
 	var forwards []ForwardedPort

--- a/pkg/util/tomb/tomb.go
+++ b/pkg/util/tomb/tomb.go
@@ -58,8 +58,7 @@
 //
 // For background and a detailed example, see the following blog post:
 //
-//   http://blog.labix.org/2011/10/09/death-of-goroutines-under-control
-//
+//	http://blog.labix.org/2011/10/09/death-of-goroutines-under-control
 package tomb
 
 import (


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation


**Please provide a short message that should be published in the DevSpace release notes**
Adding back the Runtime Variables page in the docs. It is present DevSpace v5 docs but not in v6 anymore

Fixes ENG-878