### PR TITLE
fix: add pull secret config for images during v5->v6 schema upgrade

### DIFF
--- a/e2e/tests/pullsecret/testdata/v1-upgrade/devspace.yaml
+++ b/e2e/tests/pullsecret/testdata/v1-upgrade/devspace.yaml
@@ -1,0 +1,9 @@
+version: v1beta11
+name: pullsecrets-upgrade
+images:
+  app:
+    image: registry1.example.com/username/image1
+  skip:
+    image: registry2.example.com/username/image2
+    build:
+      disabled: true

--- a/pkg/devspace/dependency/util/util_test.go
+++ b/pkg/devspace/dependency/util/util_test.go
@@ -7,8 +7,8 @@ import (
 )
 
 func TestSwitchURLType(t *testing.T) {
-	httpURL := "https://github.com/loft-sh/devspace.git"
-	sshURL := "git@github.com:loft-sh/devspace.git"
+	httpURL := "https://github.com/devspace-sh/devspace.git"
+	sshURL := "git@github.com:devspace-sh/devspace.git"
 
 	assert.Equal(t, sshURL, switchURLType(httpURL))
 	assert.Equal(t, httpURL, switchURLType(sshURL))

--- a/pkg/devspace/server/download.go
+++ b/pkg/devspace/server/download.go
@@ -23,7 +23,7 @@ import (
 )
 
 // UIRepository is the repository containing the devspace UI
-const UIRepository = "https://github.com/loft-sh/devspace"
+const UIRepository = "https://github.com/devspace-sh/devspace"
 
 // UIDownloadBaseURL is the base url where to look for the ui
 const UIDownloadBaseURL = UIRepository + "/releases/download"

--- a/pkg/devspace/services/inject/inject.go
+++ b/pkg/devspace/services/inject/inject.go
@@ -31,7 +31,7 @@ import (
 )
 
 // DevSpaceHelperRepository is the repository containing the devspace helper
-const DevSpaceHelperRepository = "https://github.com/loft-sh/devspace"
+const DevSpaceHelperRepository = "https://github.com/devspace-sh/devspace"
 
 // DevSpaceHelperBaseURL is the base url where to look for the sync helper
 const DevSpaceHelperBaseURL = DevSpaceHelperRepository + "/releases/download"
@@ -176,7 +176,7 @@ func downloadSyncHelper(ctx context.Context, helperName, syncBinaryFolder, versi
 		}
 
 		// download sha256 html
-		url := fmt.Sprintf("https://github.com/loft-sh/devspace/releases/download/%s/%s.sha256", version, helperName)
+		url := fmt.Sprintf("https://github.com/devspace-sh/devspace/releases/download/%s/%s.sha256", version, helperName)
 		req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 		if err != nil {
 			return nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
Fixes ENG-922

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace no longer creates image pull secrets for all images for v1beta11 schemas
