### PR TITLE
feat: add SkipPushKindControlPlane option in image configuration

### DIFF
--- a/cmd/run_pipeline.go
+++ b/cmd/run_pipeline.go
@@ -39,11 +39,12 @@ import (
 type RunPipelineCmd struct {
 	*flags.GlobalFlags
 
-	Tags                    []string
-	Render                  bool
-	Pipeline                string
-	SkipPush                bool
-	SkipPushLocalKubernetes bool
+	Tags                     []string
+	Render                   bool
+	Pipeline                 string
+	SkipPush                 bool
+	SkipPushLocalKubernetes  bool
+	SkipPushKindControlPlane bool
 
 	Dependency             []string
 	SkipDependency         []string
@@ -86,7 +87,7 @@ func (cmd *RunPipelineCmd) AddPipelineFlags(f factory.Factory, command *cobra.Co
 	command.Flags().StringSliceVarP(&cmd.Tags, "tag", "t", cmd.Tags, "Use the given tag for all built images")
 	command.Flags().BoolVar(&cmd.SkipPush, "skip-push", cmd.SkipPush, "Skips image pushing, useful for minikube deployment")
 	command.Flags().BoolVar(&cmd.SkipPushLocalKubernetes, "skip-push-local-kube", cmd.SkipPushLocalKubernetes, "Skips image pushing, if a local kubernetes environment is detected")
-
+	command.Flags().BoolVar(&cmd.SkipPushKindControlPlane, "skip-push-kind-control-plan", cmd.SkipPushKindControlPlane, "Skips image pushing on kind control plane node")
 	command.Flags().BoolVar(&cmd.ShowUI, "show-ui", cmd.ShowUI, "Shows the ui server")
 
 	if pipeline != nil {
@@ -398,13 +399,14 @@ func (cmd *RunPipelineCmd) BuildOptions(configOptions *loader.ConfigOptions) *Co
 		GlobalFlags: *cmd.GlobalFlags,
 		Options: types.Options{
 			BuildOptions: build.Options{
-				Tags:                      cmd.Tags,
-				SkipBuild:                 cmd.SkipBuild,
-				SkipPush:                  cmd.SkipPush,
-				SkipPushOnLocalKubernetes: cmd.SkipPushLocalKubernetes,
-				ForceRebuild:              cmd.ForceBuild,
-				Sequential:                cmd.BuildSequential,
-				MaxConcurrentBuilds:       cmd.MaxConcurrentBuilds,
+				Tags:                       cmd.Tags,
+				SkipBuild:                  cmd.SkipBuild,
+				SkipPush:                   cmd.SkipPush,
+				SkipPushOnLocalKubernetes:  cmd.SkipPushLocalKubernetes,
+				SkipPushOnKindControlPlane: cmd.SkipPushKindControlPlane,
+				ForceRebuild:               cmd.ForceBuild,
+				Sequential:                 cmd.BuildSequential,
+				MaxConcurrentBuilds:        cmd.MaxConcurrentBuilds,
 			},
 			DeployOptions: deploy.Options{
 				ForceDeploy:  cmd.ForceDeploy,

--- a/cmd/run_pipeline.go
+++ b/cmd/run_pipeline.go
@@ -39,12 +39,11 @@ import (
 type RunPipelineCmd struct {
 	*flags.GlobalFlags
 
-	Tags                     []string
-	Render                   bool
-	Pipeline                 string
-	SkipPush                 bool
-	SkipPushLocalKubernetes  bool
-	SkipPushKindControlPlane bool
+	Tags                    []string
+	Render                  bool
+	Pipeline                string
+	SkipPush                bool
+	SkipPushLocalKubernetes bool
 
 	Dependency             []string
 	SkipDependency         []string
@@ -87,7 +86,6 @@ func (cmd *RunPipelineCmd) AddPipelineFlags(f factory.Factory, command *cobra.Co
 	command.Flags().StringSliceVarP(&cmd.Tags, "tag", "t", cmd.Tags, "Use the given tag for all built images")
 	command.Flags().BoolVar(&cmd.SkipPush, "skip-push", cmd.SkipPush, "Skips image pushing, useful for minikube deployment")
 	command.Flags().BoolVar(&cmd.SkipPushLocalKubernetes, "skip-push-local-kube", cmd.SkipPushLocalKubernetes, "Skips image pushing, if a local kubernetes environment is detected")
-	command.Flags().BoolVar(&cmd.SkipPushKindControlPlane, "skip-push-kind-control-plan", cmd.SkipPushKindControlPlane, "Skips image pushing on kind control plane node")
 	command.Flags().BoolVar(&cmd.ShowUI, "show-ui", cmd.ShowUI, "Shows the ui server")
 
 	if pipeline != nil {
@@ -399,14 +397,13 @@ func (cmd *RunPipelineCmd) BuildOptions(configOptions *loader.ConfigOptions) *Co
 		GlobalFlags: *cmd.GlobalFlags,
 		Options: types.Options{
 			BuildOptions: build.Options{
-				Tags:                       cmd.Tags,
-				SkipBuild:                  cmd.SkipBuild,
-				SkipPush:                   cmd.SkipPush,
-				SkipPushOnLocalKubernetes:  cmd.SkipPushLocalKubernetes,
-				SkipPushOnKindControlPlane: cmd.SkipPushKindControlPlane,
-				ForceRebuild:               cmd.ForceBuild,
-				Sequential:                 cmd.BuildSequential,
-				MaxConcurrentBuilds:        cmd.MaxConcurrentBuilds,
+				Tags:                      cmd.Tags,
+				SkipBuild:                 cmd.SkipBuild,
+				SkipPush:                  cmd.SkipPush,
+				SkipPushOnLocalKubernetes: cmd.SkipPushLocalKubernetes,
+				ForceRebuild:              cmd.ForceBuild,
+				Sequential:                cmd.BuildSequential,
+				MaxConcurrentBuilds:       cmd.MaxConcurrentBuilds,
 			},
 			DeployOptions: deploy.Options{
 				ForceDeploy:  cmd.ForceDeploy,

--- a/devspace-schema.json
+++ b/devspace-schema.json
@@ -840,6 +840,12 @@
           "group": "pushPull",
           "group_name": "Push \u0026 Pull"
         },
+        "SkipPushOnKindControlPlane:": {
+          "type": "boolean",
+          "description": "SkipPushOnKindControlPlane will not load the image on control plane node if a Kind cluster is used.\n Only works if docker or buildkit is chosen",
+          "group": "pushPull",
+          "group_name": "Push \u0026 Pull"
+        },
         "createPullSecret": {
           "type": "boolean",
           "description": "CreatePullSecret specifies if a pull secret should be created for this image in the\ntarget namespace. Defaults to true",

--- a/docs/pages/cli/devspace_build.md
+++ b/docs/pages/cli/devspace_build.md
@@ -40,6 +40,7 @@ Builds all defined images and pushes them
       --skip-deploy                 If enabled will skip deploying
       --skip-push                   Skips image pushing, useful for minikube deployment
       --skip-push-local-kube        Skips image pushing, if a local kubernetes environment is detected
+      --skip-push-local-kube        Skips image pushing on kind control plane node
   -t, --tag strings                 Use the given tag for all built images
 ```
 

--- a/docs/pages/cli/devspace_build.md
+++ b/docs/pages/cli/devspace_build.md
@@ -40,7 +40,6 @@ Builds all defined images and pushes them
       --skip-deploy                 If enabled will skip deploying
       --skip-push                   Skips image pushing, useful for minikube deployment
       --skip-push-local-kube        Skips image pushing, if a local kubernetes environment is detected
-      --skip-push-local-kube        Skips image pushing on kind control plane node
   -t, --tag strings                 Use the given tag for all built images
 ```
 

--- a/docs/pages/configuration/_partials/v2beta1/images/group_pushpull.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/images/group_pushpull.mdx
@@ -1,11 +1,12 @@
 
 import PartialSkipPush from "./skipPush.mdx"
 import PartialCreatePullSecret from "./createPullSecret.mdx"
-
+import PartialSkipPushOnKindControlPlane from "./partialSkipPushOnKindControlPlane.mdx"
 <div className="group" data-group="pushpull">
 <div className="group-name">Push & Pull</div>
 
 <PartialSkipPush />
+<PartialSkipPushOnKindControlPlane />
 <PartialCreatePullSecret />
 
 </div>

--- a/docs/pages/configuration/_partials/v2beta1/images/partialSkipPushOnKindControlPlane.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/images/partialSkipPushOnKindControlPlane.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `skipPushOnKindControlPlane` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#images-skipPushOnKindControlPlane}
+
+SkipPushOnKindControlPlane will not load the image on control plane node if a Kind cluster is used. Only works if docker or buildkit is chosen
+
+</summary>
+
+
+
+</details>

--- a/docs/schemas/config-openapi.json
+++ b/docs/schemas/config-openapi.json
@@ -848,6 +848,12 @@
                 "group": "pushPull",
                 "group_name": "Push \u0026 Pull"
               },
+              "SkipPushOnKindControlPlane:": {
+                "type": "boolean",
+                "description": "SkipPushOnKindControlPlane will not load the image on control plane node if a Kind cluster is used.\n Only works if docker or buildkit is chosen",
+                "group": "pushPull",
+                "group_name": "Push \u0026 Pull"
+              },
               "createPullSecret": {
                 "type": "boolean",
                 "description": "CreatePullSecret specifies if a pull secret should be created for this image in the\ntarget namespace. Defaults to true",

--- a/pkg/devspace/build/build.go
+++ b/pkg/devspace/build/build.go
@@ -1,9 +1,10 @@
 package build
 
 import (
+	"strings"
+
 	dockerclient "github.com/loft-sh/devspace/pkg/devspace/docker"
 	"github.com/loft-sh/devspace/pkg/devspace/pullsecrets"
-	"strings"
 
 	"github.com/loft-sh/devspace/pkg/devspace/build/builder"
 	"github.com/loft-sh/devspace/pkg/devspace/build/types"
@@ -27,12 +28,13 @@ type imageNameAndTag struct {
 
 // Options describe how images should be build
 type Options struct {
-	Tags                      []string `long:"tag" short:"t" description:"If enabled will override the default tags"`
-	SkipBuild                 bool     `long:"skip" description:"If enabled will skip building"`
-	SkipPush                  bool     `long:"skip-push" description:"Skip pushing"`
-	SkipPushOnLocalKubernetes bool     `long:"skip-push-on-local-kubernetes" description:"Skip pushing"`
-	ForceRebuild              bool     `long:"force-rebuild" description:"Skip pushing"`
-	Sequential                bool     `long:"sequential" description:"Skip pushing"`
+	Tags                       []string `long:"tag" short:"t" description:"If enabled will override the default tags"`
+	SkipBuild                  bool     `long:"skip" description:"If enabled will skip building"`
+	SkipPush                   bool     `long:"skip-push" description:"Skip pushing"`
+	SkipPushOnLocalKubernetes  bool     `long:"skip-push-on-local-kubernetes" description:"Skip pushing"`
+	SkipPushOnKindControlPlane bool     `long:"skip-push-on-kind-control-plane" description:"Skip pushing"`
+	ForceRebuild               bool     `long:"force-rebuild" description:"Skip pushing"`
+	Sequential                 bool     `long:"sequential" description:"Skip pushing"`
 
 	MaxConcurrentBuilds int `long:"max-concurrent" description:"A pointer to an integer"`
 }

--- a/pkg/devspace/build/build.go
+++ b/pkg/devspace/build/build.go
@@ -28,13 +28,12 @@ type imageNameAndTag struct {
 
 // Options describe how images should be build
 type Options struct {
-	Tags                       []string `long:"tag" short:"t" description:"If enabled will override the default tags"`
-	SkipBuild                  bool     `long:"skip" description:"If enabled will skip building"`
-	SkipPush                   bool     `long:"skip-push" description:"Skip pushing"`
-	SkipPushOnLocalKubernetes  bool     `long:"skip-push-on-local-kubernetes" description:"Skip pushing"`
-	SkipPushOnKindControlPlane bool     `long:"skip-push-on-kind-control-plane" description:"Skip pushing"`
-	ForceRebuild               bool     `long:"force-rebuild" description:"Skip pushing"`
-	Sequential                 bool     `long:"sequential" description:"Skip pushing"`
+	Tags                      []string `long:"tag" short:"t" description:"If enabled will override the default tags"`
+	SkipBuild                 bool     `long:"skip" description:"If enabled will skip building"`
+	SkipPush                  bool     `long:"skip-push" description:"Skip pushing"`
+	SkipPushOnLocalKubernetes bool     `long:"skip-push-on-local-kubernetes" description:"Skip pushing"`
+	ForceRebuild              bool     `long:"force-rebuild" description:"Skip pushing"`
+	Sequential                bool     `long:"sequential" description:"Skip pushing"`
 
 	MaxConcurrentBuilds int `long:"max-concurrent" description:"A pointer to an integer"`
 }

--- a/pkg/devspace/build/builder/buildkit/buildkit.go
+++ b/pkg/devspace/build/builder/buildkit/buildkit.go
@@ -35,14 +35,13 @@ const EngineName = "buildkit"
 
 // Builder holds the necessary information to build and push docker images
 type Builder struct {
-	helper                     *helper.BuildHelper
-	skipPush                   bool
-	skipPushOnLocalKubernetes  bool
-	skipPushOnKindControlPlane bool
+	helper                    *helper.BuildHelper
+	skipPush                  bool
+	skipPushOnLocalKubernetes bool
 }
 
 // NewBuilder creates a new docker Builder instance
-func NewBuilder(ctx devspacecontext.Context, imageConf *latest.Image, imageTags []string, skipPush, skipPushOnLocalKubernetes, skipPushOnKindControlPlane bool) (*Builder, error) {
+func NewBuilder(ctx devspacecontext.Context, imageConf *latest.Image, imageTags []string, skipPush, skipPushOnLocalKubernetes bool) (*Builder, error) {
 	// ensure namespace
 	if imageConf.BuildKit != nil && imageConf.BuildKit.InCluster != nil && imageConf.BuildKit.InCluster.Namespace != "" {
 		err := kubectl.EnsureNamespace(ctx.Context(), ctx.KubeClient(), imageConf.BuildKit.InCluster.Namespace, ctx.Log())
@@ -52,10 +51,9 @@ func NewBuilder(ctx devspacecontext.Context, imageConf *latest.Image, imageTags 
 	}
 
 	return &Builder{
-		helper:                     helper.NewBuildHelper(ctx, EngineName, imageConf, imageTags),
-		skipPush:                   skipPush,
-		skipPushOnLocalKubernetes:  skipPushOnLocalKubernetes,
-		skipPushOnKindControlPlane: skipPushOnKindControlPlane,
+		helper:                    helper.NewBuildHelper(ctx, EngineName, imageConf, imageTags),
+		skipPush:                  skipPush,
+		skipPushOnLocalKubernetes: skipPushOnLocalKubernetes,
 	}, nil
 }
 
@@ -123,7 +121,7 @@ func (b *Builder) BuildImage(ctx devspacecontext.Context, contextPath, dockerfil
 
 	// Should we build with cli?
 	skipPush := b.skipPush || b.helper.ImageConf.SkipPush
-	skipPushOnKindControlPlane := b.skipPushOnKindControlPlane || b.helper.ImageConf.SkipPushOnKindControlPlane
+	skipPushOnKindControlPlane := b.helper.ImageConf.SkipPushOnKindControlPlane
 	return buildWithCLI(ctx.Context(), ctx.WorkingDir(), ctx.Environ(), body, writer, ctx.KubeClient(), builder, buildKitConfig, *buildOptions, useMinikubeDocker, skipPush, skipPushOnKindControlPlane, ctx.Log())
 }
 

--- a/pkg/devspace/build/builder/buildkit/buildkit.go
+++ b/pkg/devspace/build/builder/buildkit/buildkit.go
@@ -207,6 +207,7 @@ func buildWithCLI(ctx context.Context, dir string, environ expand.Environ, conte
 		kindWorkers := ""
 		if skipPushOnKindControlPlane {
 			kindWorkers, _ = kubectl.GetKindWorkerNodes(kubeClient.CurrentContext())
+			log.Infof("Will only push on %s", kindWorkers)
 		}
 		for _, tag := range options.Tags {
 			command := []string{"kind", "load", "docker-image", "--name", kubectl.GetKindContext(kubeClient.CurrentContext()), tag}

--- a/pkg/devspace/build/builder/docker/docker.go
+++ b/pkg/devspace/build/builder/docker/docker.go
@@ -33,7 +33,7 @@ type Builder struct {
 	client                     dockerclient.Client
 	skipPush                   bool
 	skipPushOnLocalKubernetes  bool
-	SkipPushOnKindControlPlane bool
+	skipPushOnKindControlPlane bool
 }
 
 // NewBuilder creates a new docker Builder instance
@@ -43,7 +43,7 @@ func NewBuilder(ctx devspacecontext.Context, client dockerclient.Client, imageCo
 		client:                     client,
 		skipPush:                   skipPush,
 		skipPushOnLocalKubernetes:  skipPushOnLocalKubernetes,
-		SkipPushOnKindControlPlane: skipPushOnKindControlPlane,
+		skipPushOnKindControlPlane: skipPushOnKindControlPlane,
 	}, nil
 }
 
@@ -165,7 +165,7 @@ func (b *Builder) BuildImage(ctx devspacecontext.Context, contextPath, dockerfil
 	} else if ctx.KubeClient() != nil && kubectl.GetKindContext(ctx.KubeClient().CurrentContext()) != "" {
 		// Load image if it is a kind-context
 		kindWorkers := ""
-		if b.SkipPushOnKindControlPlane || b.helper.ImageConf.SkipPushOnKindControlPlane {
+		if b.skipPushOnKindControlPlane || b.helper.ImageConf.SkipPushOnKindControlPlane {
 			kindWorkers, _ = kubectl.GetKindWorkerNodes(ctx.KubeClient().CurrentContext())
 			ctx.Log().Info("Will only push on %s", kindWorkers)
 		}

--- a/pkg/devspace/build/builder/docker/docker.go
+++ b/pkg/devspace/build/builder/docker/docker.go
@@ -165,7 +165,7 @@ func (b *Builder) BuildImage(ctx devspacecontext.Context, contextPath, dockerfil
 		kindWorkers := ""
 		if b.helper.ImageConf.SkipPushOnKindControlPlane {
 			kindWorkers, _ = kubectl.GetKindWorkerNodes(ctx.KubeClient().CurrentContext())
-			ctx.Log().Info("Will only push on %s", kindWorkers)
+			ctx.Log().Infof("Will only push on %s", kindWorkers)
 		}
 		for _, tag := range buildOptions.Tags {
 			command := []string{"kind", "load", "docker-image", "--name", kubectl.GetKindContext(ctx.KubeClient().CurrentContext()), tag}

--- a/pkg/devspace/build/builder/docker/docker.go
+++ b/pkg/devspace/build/builder/docker/docker.go
@@ -29,21 +29,19 @@ const EngineName = "docker"
 type Builder struct {
 	helper *helper.BuildHelper
 
-	authConfig                 *types.AuthConfig
-	client                     dockerclient.Client
-	skipPush                   bool
-	skipPushOnLocalKubernetes  bool
-	skipPushOnKindControlPlane bool
+	authConfig                *types.AuthConfig
+	client                    dockerclient.Client
+	skipPush                  bool
+	skipPushOnLocalKubernetes bool
 }
 
 // NewBuilder creates a new docker Builder instance
-func NewBuilder(ctx devspacecontext.Context, client dockerclient.Client, imageConf *latest.Image, imageTags []string, skipPush, skipPushOnLocalKubernetes, skipPushOnKindControlPlane bool) (*Builder, error) {
+func NewBuilder(ctx devspacecontext.Context, client dockerclient.Client, imageConf *latest.Image, imageTags []string, skipPush, skipPushOnLocalKubernetes bool) (*Builder, error) {
 	return &Builder{
-		helper:                     helper.NewBuildHelper(ctx, EngineName, imageConf, imageTags),
-		client:                     client,
-		skipPush:                   skipPush,
-		skipPushOnLocalKubernetes:  skipPushOnLocalKubernetes,
-		skipPushOnKindControlPlane: skipPushOnKindControlPlane,
+		helper:                    helper.NewBuildHelper(ctx, EngineName, imageConf, imageTags),
+		client:                    client,
+		skipPush:                  skipPush,
+		skipPushOnLocalKubernetes: skipPushOnLocalKubernetes,
 	}, nil
 }
 
@@ -165,7 +163,7 @@ func (b *Builder) BuildImage(ctx devspacecontext.Context, contextPath, dockerfil
 	} else if ctx.KubeClient() != nil && kubectl.GetKindContext(ctx.KubeClient().CurrentContext()) != "" {
 		// Load image if it is a kind-context
 		kindWorkers := ""
-		if b.skipPushOnKindControlPlane || b.helper.ImageConf.SkipPushOnKindControlPlane {
+		if b.helper.ImageConf.SkipPushOnKindControlPlane {
 			kindWorkers, _ = kubectl.GetKindWorkerNodes(ctx.KubeClient().CurrentContext())
 			ctx.Log().Info("Will only push on %s", kindWorkers)
 		}

--- a/pkg/devspace/build/create_builder.go
+++ b/pkg/devspace/build/create_builder.go
@@ -37,7 +37,7 @@ func (c *controller) createBuilder(ctx devspacecontext.Context, imageConf *lates
 	if imageConf.Custom != nil {
 		bldr = custom.NewBuilder(imageConf, imageTags)
 	} else if imageConf.BuildKit != nil {
-		bldr, err = buildkit.NewBuilder(ctx, imageConf, imageTags, options.SkipPush, options.SkipPushOnLocalKubernetes, options.SkipPushOnKindControlPlane)
+		bldr, err = buildkit.NewBuilder(ctx, imageConf, imageTags, options.SkipPush, options.SkipPushOnLocalKubernetes)
 		if err != nil {
 			return nil, errors.Errorf("Error creating kaniko builder: %v", err)
 		}
@@ -89,7 +89,7 @@ func (c *controller) createBuilder(ctx devspacecontext.Context, imageConf *lates
 			return localRegistryBuilder(ctx, imageConf, imageTags, options)
 		}
 
-		bldr, err = docker.NewBuilder(ctx, dockerClient, imageConf, imageTags, options.SkipPush, options.SkipPushOnLocalKubernetes, options.SkipPushOnKindControlPlane)
+		bldr, err = docker.NewBuilder(ctx, dockerClient, imageConf, imageTags, options.SkipPush, options.SkipPushOnLocalKubernetes)
 		if err != nil {
 			return nil, errors.Errorf("Error creating docker builder: %v", err)
 		}

--- a/pkg/devspace/build/create_builder.go
+++ b/pkg/devspace/build/create_builder.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"fmt"
+
 	"github.com/loft-sh/devspace/pkg/devspace/build/builder"
 	"github.com/loft-sh/devspace/pkg/devspace/build/builder/buildkit"
 	"github.com/loft-sh/devspace/pkg/devspace/build/builder/custom"
@@ -36,7 +37,7 @@ func (c *controller) createBuilder(ctx devspacecontext.Context, imageConf *lates
 	if imageConf.Custom != nil {
 		bldr = custom.NewBuilder(imageConf, imageTags)
 	} else if imageConf.BuildKit != nil {
-		bldr, err = buildkit.NewBuilder(ctx, imageConf, imageTags, options.SkipPush, options.SkipPushOnLocalKubernetes)
+		bldr, err = buildkit.NewBuilder(ctx, imageConf, imageTags, options.SkipPush, options.SkipPushOnLocalKubernetes, options.SkipPushOnKindControlPlane)
 		if err != nil {
 			return nil, errors.Errorf("Error creating kaniko builder: %v", err)
 		}
@@ -88,7 +89,7 @@ func (c *controller) createBuilder(ctx devspacecontext.Context, imageConf *lates
 			return localRegistryBuilder(ctx, imageConf, imageTags, options)
 		}
 
-		bldr, err = docker.NewBuilder(ctx, dockerClient, imageConf, imageTags, options.SkipPush, options.SkipPushOnLocalKubernetes)
+		bldr, err = docker.NewBuilder(ctx, dockerClient, imageConf, imageTags, options.SkipPush, options.SkipPushOnLocalKubernetes, options.SkipPushOnKindControlPlane)
 		if err != nil {
 			return nil, errors.Errorf("Error creating docker builder: %v", err)
 		}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -286,6 +286,9 @@ type Image struct {
 	// as build method
 	SkipPush bool `yaml:"skipPush,omitempty" json:"skipPush,omitempty" jsonschema_extras:"group=pushPull,group_name=Push & Pull"`
 
+	// SkipPushOnKindControlPlane will not load the image on control plane node if a Kind cluster is used Only works if docker or buildkit is chosen
+	SkipPushOnKindControlPlane bool `yaml:"skipPushOnKindControlPlane,omitempty" json:"skipPushOnKindControlPlane,omitempty" jsonschema_extras:"group=pushPull,group_name=Push & Pull"`
+
 	// CreatePullSecret specifies if a pull secret should be created for this image in the
 	// target namespace. Defaults to true
 	CreatePullSecret *bool `yaml:"createPullSecret,omitempty" json:"createPullSecret,omitempty" jsonschema:"required" jsonschema_extras:"group=pushPull"`

--- a/pkg/devspace/kubectl/util.go
+++ b/pkg/devspace/kubectl/util.go
@@ -1,10 +1,12 @@
 package kubectl
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net"
 	"net/http"
+	"os/exec"
 	"strings"
 
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/portforward"
@@ -239,4 +241,16 @@ func GetKindContext(context string) string {
 	}
 
 	return strings.TrimPrefix(context, "kind-")
+}
+
+func GetKindWorkerNodes(context string) (string, error) {
+	cmd := exec.Command("docker", "ps", "-f", fmt.Sprintf("label=io.x-k8s.kind.cluster=%s", GetKindContext(context)), "-f", "label=io.x-k8s.kind.role=worker", "--format", "{{.Names}}")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", err
+	}
+	nodes := strings.Trim(strings.Replace(out.String(), "\n", ",", -1), ",")
+	return nodes, nil
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Add an option called `skipPushOnKindControlPlane` on to only target worker node when pushing docker images using kind binary


**Please provide a short message that should be published in the DevSpace release notes**
Add an option to prevent images to be push on kind control plane node,

