### PR TITLE
fix: resolve upgrade command bug

### DIFF
--- a/vendor/github.com/loft-sh/go-github-selfupdate/selfupdate/update.go
+++ b/vendor/github.com/loft-sh/go-github-selfupdate/selfupdate/update.go
@@ -2,6 +2,7 @@ package selfupdate
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -12,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/blang/semver"
+	"github.com/google/go-github/v30/github"
 	"github.com/inconshreveable/go-update"
 )
 
@@ -57,17 +59,32 @@ func (up *Updater) downloadDirectlyFromURL(assetURL string) (io.ReadCloser, erro
 // If a redirect occurs, it fallbacks into directly downloading from the redirect URL.
 func (up *Updater) UpdateTo(rel *Release, cmdPath string) error {
 	var client http.Client
+
+	// src in this case, is *not* the asset itself, but the json response of the asset API:
+	// GitHub API docs: https://developer.github.com/v3/repos/releases/#get-a-single-release-asset
 	src, redirectURL, err := up.api.Repositories.DownloadReleaseAsset(up.apiCtx, rel.RepoOwner, rel.RepoName, rel.AssetID, &client)
 	if err != nil {
 		return fmt.Errorf("Failed to call GitHub Releases API for getting an asset(ID: %d) for repository '%s/%s': %s", rel.AssetID, rel.RepoOwner, rel.RepoName, err)
 	}
-	if redirectURL != "" {
-		log.Println("Redirect URL was returned while trying to download a release asset from GitHub API. Falling back to downloading from asset URL directly:", redirectURL)
-		src, err = up.downloadDirectlyFromURL(redirectURL)
+
+	// In case we *do not* have a redirect url, we extract the download url from
+	// the json response of up.api.Repositories.DownloadReleaseAsset
+	if redirectURL == "" {
+		// Unmashal the incoming releaseasset response to ReleaseAsset
+		asset := github.ReleaseAsset{}
+		err = json.NewDecoder(src).Decode(&asset)
 		if err != nil {
 			return err
 		}
+		redirectURL = *asset.BrowserDownloadURL
 	}
+
+	// Then with the result, or with the original redirectURL we directly download the asset
+	src, err = up.downloadDirectlyFromURL(redirectURL)
+	if err != nil {
+		return err
+	}
+
 	defer src.Close()
 
 	data, err := io.ReadAll(src)


### PR DESCRIPTION
There was a situation where DownloadReleaseAsset's result was treated
like the asset downloaded.
This lead to the download of a json file, instead of the upgraded
devspace.

This fix extracts the real binary url to download, and uses then that to
perform the upgrade process.

Closes #2516
Closes ENG-933

/kind bugfix

Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>