### PR TITLE
fix: make command flags available everywhere for get_flags

### DIFF
--- a/cmd/run_pipeline.go
+++ b/cmd/run_pipeline.go
@@ -247,7 +247,7 @@ func (cmd *RunPipelineCmd) Run(cobraCmd *cobra.Command, args []string, f factory
 
 	// set command in context
 	if cobraCmd != nil {
-		cmd.Ctx = values.WithFlags(cmd.Ctx, cobraCmd.Flags())
+		cmd.Ctx = values.WithCommandFlags(cmd.Ctx, cobraCmd.Flags())
 	}
 	options := cmd.BuildOptions(cmd.ToConfigOptions())
 	ctx, err := initialize(cmd.Ctx, f, options, cmd.Log)

--- a/e2e/tests/pipelines/pipelines.go
+++ b/e2e/tests/pipelines/pipelines.go
@@ -42,30 +42,41 @@ var _ = DevSpaceDescribe("pipelines", func() {
 		framework.ExpectNoError(err)
 		defer framework.ExpectDeleteNamespace(kubeClient, ns)
 
+		rootCmd := cmd.NewRootCmd(f)
+		persistentFlags := rootCmd.PersistentFlags()
+		globalFlags := flags.SetGlobalFlags(persistentFlags)
+		globalFlags.NoWarn = true
+		globalFlags.Namespace = ns
+		globalFlags.Profiles = []string{"profile1"}
+
+		cmdCtx := values.WithCommandFlags(context.Background(), globalFlags.Flags)
+		cmdCtx = values.WithFlagsMap(cmdCtx, map[string]string{
+			"test":  "test",
+			"test2": "",
+		})
+
 		devCmd := &cmd.RunPipelineCmd{
-			GlobalFlags: &flags.GlobalFlags{
-				NoWarn:    true,
-				Namespace: ns,
-			},
-			Pipeline: "dev",
-			Ctx: values.WithFlagsMap(context.Background(), map[string]string{
-				"test":  "test",
-				"test2": "",
-			}),
+			GlobalFlags: globalFlags,
+			Pipeline:    "dev",
+			Ctx:         cmdCtx,
 		}
 		err = devCmd.RunDefault(f)
 		framework.ExpectNoError(err)
 
 		framework.ExpectLocalFileContentsImmediately("test.txt", "test\n")
 		framework.ExpectLocalFileContentsImmediately("test2.txt", "\n")
+		framework.ExpectLocalFileContentsImmediately("dev-profile.txt", "profile1\n")
 		framework.ExpectLocalFileContentsImmediately("other.txt", "test\n")
 		framework.ExpectLocalFileContentsImmediately("other2.txt", "false\n")
 		framework.ExpectLocalFileContentsImmediately("other3.txt", "true\n")
+		framework.ExpectLocalFileContentsImmediately("other-profile.txt", "profile1\n")
 		framework.ExpectLocalFileContentsImmediately("dep1-test.txt", "test\n")
 		framework.ExpectLocalFileContentsImmediately("dep1-test2.txt", "true\n")
+		framework.ExpectLocalFileContentsImmediately("dep1-dev-profile.txt", "profile1\n")
 		framework.ExpectLocalFileContentsImmediately("dep1-other.txt", "test\n")
 		framework.ExpectLocalFileContentsImmediately("dep1-other2.txt", "false\n")
 		framework.ExpectLocalFileContentsImmediately("dep1-other3.txt", "false\n")
+		framework.ExpectLocalFileContentsImmediately("dep1-other-profile.txt", "profile1\n")
 	})
 
 	ginkgo.It("should exec container", func() {

--- a/e2e/tests/pipelines/testdata/flags/dep1.yaml
+++ b/e2e/tests/pipelines/testdata/flags/dep1.yaml
@@ -19,6 +19,7 @@ pipelines:
       echo $(get_flag other) > dep1-other.txt
       echo $(get_flag other2) > dep1-other2.txt
       echo $(get_flag other3) > dep1-other3.txt
+      echo $(get_flag profile) > dep1-other-profile.txt
 
   dev:
     flags:
@@ -32,4 +33,5 @@ pipelines:
         exit 1
       fi
       echo $(get_flag test3) > dep1-test2.txt
+      echo $(get_flag profile) > dep1-dev-profile.txt
       run_pipelines other --set-flag other2=false

--- a/e2e/tests/pipelines/testdata/flags/devspace.yaml
+++ b/e2e/tests/pipelines/testdata/flags/devspace.yaml
@@ -23,6 +23,7 @@ pipelines:
       echo $(get_flag other) > other.txt
       echo $(get_flag other2) > other2.txt
       echo $(get_flag other3) > other3.txt
+      echo $(get_flag profile) > other-profile.txt
 
   dev:
     flags:
@@ -33,11 +34,19 @@ pipelines:
     run: |-
       echo "$(get_flag test)" > test.txt
       echo "$(get_flag test2)" > test2.txt
+      echo "$(get_flag profile)" > dev-profile.txt
       
       run_pipelines other --set-flag other2=false
       run_dependencies dep1 --set-flag test3=true --pipeline dev
       
-      
-      
+profiles:
+  - name: profile1
+    patches:
+      - op: add
+        path: pipelines
+        value:
+          noop:
+            run: |-
+              echo "noop"
 
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #2461
Fixes ENG-761

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where dependencies pipelines could not access command flags using `get_flag` 

**What else do we need to know?** 
No docs update needed