### PR TITLE
fix: tag replaced incorrectly when using dev.*.imageSelector with pre…

### DIFF
--- a/pkg/devspace/config/loader/variable/legacy/replace.go
+++ b/pkg/devspace/config/loader/variable/legacy/replace.go
@@ -175,7 +175,7 @@ func resolveImage(value string, config config2.Config, dependencies []types.Depe
 
 		// try to find the tag for the image
 		tag := originalTag
-		if imageCache.Tag != "" {
+		if tag == "" && imageCache.Tag != "" {
 			tag = imageCache.Tag
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Fixes ENG-969


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would use an incorrect image selector if it includes a tag.
