### PR TITLE
fix: add missing block in docs. #2544

### DIFF
--- a/docs/pages/configuration/deployments/kubectl/inline_manifests.mdx
+++ b/docs/pages/configuration/deployments/kubectl/inline_manifests.mdx
@@ -22,7 +22,7 @@ pipelines:
 deployments:
   backend:
     kubectl:
-      inlineManifest:
+      inlineManifest: |-
         apiVersion: v1
         kind: Pod
         metadata:
@@ -79,7 +79,7 @@ The `createArgs` option expects an array of strings stating additional arguments
 deployments:
   backend:
     kubectl:
-      inlineManifest:
+      inlineManifest: |-
         apiVersion: v1
         kind: Pod
         metadata:


### PR DESCRIPTION
Signed-off-by: Luca Di Maio <luca.dimaio1@gmail.com>

/kind bugfix
/kind documentation

Fix missing blocks for `inlineManifest` 