### PR TITLE
fix: continue even if a dev config has no Ports when running list ports

### DIFF
--- a/cmd/list/ports.go
+++ b/cmd/list/ports.go
@@ -2,6 +2,7 @@ package list
 
 import (
 	"context"
+
 	"github.com/loft-sh/devspace/cmd/flags"
 	"github.com/loft-sh/devspace/pkg/util/factory"
 	"github.com/loft-sh/devspace/pkg/util/log"
@@ -57,8 +58,7 @@ func (cmd *portsCmd) RunListPort(f factory.Factory, cobraCmd *cobra.Command, arg
 	portForwards := make([][]string, 0)
 	for _, dev := range config.Dev {
 		if dev.Ports == nil || len(dev.Ports) == 0 {
-			logger.Info("No ports are forwarded.\n")
-			return nil
+			continue
 		}
 		selector := ""
 		for k, v := range dev.LabelSelector {
@@ -76,7 +76,10 @@ func (cmd *portsCmd) RunListPort(f factory.Factory, cobraCmd *cobra.Command, arg
 			})
 		}
 	}
-
+	if len(portForwards) == 0 {
+		logger.Info("No ports are forwarded.\n")
+		return nil
+	}
 	headerColumnNames := []string{
 		"ImageSelector",
 		"LabelSelector",


### PR DESCRIPTION

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2557


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace doe not list forwarded ports when one entry in the dev section has none configured


**What else do we need to know?** 
