### PR TITLE
feat: add patches to kubectl deployments

### DIFF
--- a/devspace-schema.json
+++ b/devspace-schema.json
@@ -745,12 +745,15 @@
           "type": "array",
           "description": "TemplateArgs are additional arguments to pass to `helm template`"
         },
-        "disableDependencyUpdate" : {
+        "disableDependencyUpdate": {
           "type": "boolean",
-          "description" : "DisableDependencyUpdate disables helm dependencies update"
+          "description": "DisableDependencyUpdate disables helm dependencies update, default to false"
         }
       },
       "type": "object",
+      "required": [
+        "disableDependencyUpdate"
+      ],
       "description": "HelmConfig defines the specific helm options used during deployment"
     },
     "Image": {
@@ -1188,7 +1191,7 @@
         },
         "inlineManifest": {
           "type": "string",
-          "description": "InlineManists is a block containing the manifest to deploy"
+          "description": "InlineManifests is a block containing the manifest to deploy"
         },
         "kustomize": {
           "type": "boolean",
@@ -1208,6 +1211,14 @@
           "type": "string",
           "description": "KustomizeBinaryPath is the optional path where to find the kustomize binary",
           "group": "kustomize"
+        },
+        "patches": {
+          "items": {
+            "$ref": "#/$defs/PatchTarget"
+          },
+          "type": "array",
+          "description": "Patches are additional changes to the pod spec that should be applied",
+          "group": "modifications"
         }
       },
       "type": "object",
@@ -1308,6 +1319,32 @@
         "path"
       ],
       "description": "PatchConfig describes a config patch and how it should be applied"
+    },
+    "PatchTarget": {
+      "properties": {
+        "target": {
+          "$ref": "#/$defs/Target",
+          "description": "Target describes where to apply a config patch"
+        },
+        "op": {
+          "type": "string",
+          "description": "Operation is the path operation to do. Can be either replace, add or remove"
+        },
+        "path": {
+          "type": "string",
+          "description": "Path is the config path to apply the patch to"
+        },
+        "value": {
+          "description": "Value is the value to use for this patch."
+        }
+      },
+      "type": "object",
+      "required": [
+        "target",
+        "op",
+        "path"
+      ],
+      "description": "PatchTarget describes a config patch and how it should be applied"
     },
     "PersistenceOptions": {
       "properties": {
@@ -1809,6 +1846,29 @@
       },
       "type": "object",
       "description": "SyncOnUpload defines the struct for the command that should be executed when files / folders are uploaded"
+    },
+    "Target": {
+      "properties": {
+        "apiVersion": {
+          "type": "string",
+          "description": "ApiVersion is the Kubernetes api of the target resource"
+        },
+        "kind": {
+          "type": "string",
+          "description": "Kind is the kind of the target resource (eg: Deployment, Service ...)"
+        },
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the target resource"
+        }
+      },
+      "type": "object",
+      "required": [
+        "apiVersion",
+        "kind",
+        "name"
+      ],
+      "description": "Target describes where to apply a config patch"
     },
     "Terminal": {
       "properties": {

--- a/docs/pages/cli/devspace_build.md
+++ b/docs/pages/cli/devspace_build.md
@@ -34,12 +34,13 @@ Builds all defined images and pushes them
       --max-concurrent-builds int   The maximum number of image builds built in parallel (0 for infinite)
       --pipeline string             The pipeline to execute (default "build")
       --render                      If true will render manifests and print them instead of actually deploying them
+      --sequential-dependencies     If set set true dependencies will run sequentially
       --show-ui                     Shows the ui server
       --skip-build                  Skips building of images
       --skip-dependency strings     Skips the following dependencies for deployment
       --skip-deploy                 If enabled will skip deploying
       --skip-push                   Skips image pushing, useful for minikube deployment
-      --skip-push-local-kube        Skips image pushing, if a local kubernetes environment is detected
+      --skip-push-local-kube        Skips image pushing, if a local kubernetes environment is detected (default true)
   -t, --tag strings                 Use the given tag for all built images
 ```
 

--- a/docs/pages/cli/devspace_deploy.md
+++ b/docs/pages/cli/devspace_deploy.md
@@ -38,6 +38,7 @@ devspace deploy --kube-context=deploy-context
       --max-concurrent-builds int   The maximum number of image builds built in parallel (0 for infinite)
       --pipeline string             The pipeline to execute (default "deploy")
       --render                      If true will render manifests and print them instead of actually deploying them
+      --sequential-dependencies     If set set true dependencies will run sequentially
       --show-ui                     Shows the ui server
       --skip-build                  Skips building of images
       --skip-dependency strings     Skips the following dependencies for deployment

--- a/docs/pages/cli/devspace_dev.md
+++ b/docs/pages/cli/devspace_dev.md
@@ -34,6 +34,7 @@ Starts your project in development mode
       --max-concurrent-builds int   The maximum number of image builds built in parallel (0 for infinite)
       --pipeline string             The pipeline to execute (default "dev")
       --render                      If true will render manifests and print them instead of actually deploying them
+      --sequential-dependencies     If set set true dependencies will run sequentially
       --show-ui                     Shows the ui server
       --skip-build                  Skips building of images
       --skip-dependency strings     Skips the following dependencies for deployment

--- a/docs/pages/cli/devspace_purge.md
+++ b/docs/pages/cli/devspace_purge.md
@@ -36,6 +36,7 @@ devspace purge
       --max-concurrent-builds int   The maximum number of image builds built in parallel (0 for infinite)
       --pipeline string             The pipeline to execute (default "purge")
       --render                      If true will render manifests and print them instead of actually deploying them
+      --sequential-dependencies     If set set true dependencies will run sequentially
       --show-ui                     Shows the ui server
       --skip-build                  Skips building of images
       --skip-dependency strings     Skips the following dependencies for deployment

--- a/docs/pages/cli/devspace_render.md
+++ b/docs/pages/cli/devspace_render.md
@@ -36,6 +36,7 @@ deployment.
       --max-concurrent-builds int   The maximum number of image builds built in parallel (0 for infinite)
       --pipeline string             The pipeline to execute (default "deploy")
       --render                      If true will render manifests and print them instead of actually deploying them (default true)
+      --sequential-dependencies     If set set true dependencies will run sequentially
       --show-ui                     Shows the ui server
       --skip-build                  Skips building of images
       --skip-dependency strings     Skips the following dependencies for deployment

--- a/docs/pages/cli/devspace_run-pipeline.md
+++ b/docs/pages/cli/devspace_run-pipeline.md
@@ -36,6 +36,7 @@ devspace run-pipeline dev
       --max-concurrent-builds int   The maximum number of image builds built in parallel (0 for infinite)
       --pipeline string             The pipeline to execute
       --render                      If true will render manifests and print them instead of actually deploying them
+      --sequential-dependencies     If set set true dependencies will run sequentially
       --show-ui                     Shows the ui server
       --skip-build                  Skips building of images
       --skip-dependency strings     Skips the following dependencies for deployment

--- a/docs/pages/cli/devspace_sync.md
+++ b/docs/pages/cli/devspace_sync.md
@@ -24,7 +24,7 @@ devspace sync --path=.:/app # localPath is current dir and remotePath is /app
 devspace sync --path=.:/app --image-selector nginx:latest
 devspace sync --path=.:/app --exclude=node_modules,test
 devspace sync --path=.:/app --pod=my-pod --container=my-container
-#############################################################################`
+#############################################################################
 ```
 
 
@@ -65,3 +65,4 @@ devspace sync --path=.:/app --pod=my-pod --container=my-container
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project
       --var strings                  Variables to override during execution (e.g. --var=MYVAR=MYVALUE)
 ```
+

--- a/docs/pages/configuration/_partials/v2beta1/deployments/helm/disableDependencyUpdate.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/helm/disableDependencyUpdate.mdx
@@ -4,9 +4,10 @@
 
 #### `disableDependencyUpdate` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deployments-helm-disableDependencyUpdate}
 
-DisableDependencyUpdate disables helm dependencies update
+DisableDependencyUpdate disables helm dependencies update, default to false
 
 </summary>
+
 
 
 </details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/helm_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/helm_reference.mdx
@@ -41,4 +41,5 @@ Chart holds the chart configuration and where DevSpace can find the chart
 
 <PartialTemplateArgs />
 
+
 <PartialDisableDependencyUpdate />

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/group_modifications.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/group_modifications.mdx
@@ -1,0 +1,19 @@
+
+import PartialPatchesreference from "./patches_reference.mdx"
+
+<div className="group" data-group="modifications">
+<details className="config-field" data-expandable="true">
+<summary>
+
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches}
+
+Patches are additional changes to the pod spec that should be applied
+
+</summary>
+
+<PartialPatchesreference />
+
+
+</details>
+
+</div>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches.mdx
@@ -1,0 +1,17 @@
+
+import PartialPatchesreference from "./patches_reference.mdx"
+
+
+<details className="config-field" data-expandable="true" open>
+<summary>
+
+#### `patches` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches}
+
+Patches are additional changes to the pod spec that should be applied
+
+</summary>
+
+<PartialPatchesreference />
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/op.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/op.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `op` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches-op}
+
+Operation is the path operation to do. Can be either replace, add or remove
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/path.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/path.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `path` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches-path}
+
+Path is the config path to apply the patch to
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target.mdx
@@ -1,0 +1,17 @@
+
+import PartialTargetreference from "./target_reference.mdx"
+
+
+<details className="config-field" data-expandable="true" open>
+<summary>
+
+##### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches-target}
+
+Target describes where to apply a config patch
+
+</summary>
+
+<PartialTargetreference />
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target/apiVersion.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target/apiVersion.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+###### `apiVersion` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches-target-apiVersion}
+
+ApiVersion is the Kubernetes api of the target resource
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target/kind.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target/kind.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+###### `kind` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches-target-kind}
+
+Kind is the kind of the target resource (eg: Deployment, Service ...)
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target/name.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target/name.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+###### `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches-target-name}
+
+Name is the name of the target resource
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/target_reference.mdx
@@ -1,0 +1,12 @@
+
+import PartialApiVersion from "./target/apiVersion.mdx"
+import PartialKind from "./target/kind.mdx"
+import PartialName from "./target/name.mdx"
+
+<PartialApiVersion />
+
+
+<PartialKind />
+
+
+<PartialName />

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/value.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches/value.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+##### `value` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches-value}
+
+Value is the value to use for this patch.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl/patches_reference.mdx
@@ -1,0 +1,29 @@
+
+import PartialTargetreference from "./patches/target_reference.mdx"
+import PartialOp from "./patches/op.mdx"
+import PartialPath from "./patches/path.mdx"
+import PartialValue from "./patches/value.mdx"
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+##### `target` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#deployments-kubectl-patches-target}
+
+Target describes where to apply a config patch
+
+</summary>
+
+<PartialTargetreference />
+
+
+</details>
+
+
+<PartialOp />
+
+
+<PartialPath />
+
+
+<PartialValue />

--- a/docs/pages/configuration/_partials/v2beta1/deployments/kubectl_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/kubectl_reference.mdx
@@ -5,6 +5,7 @@ import PartialCreateArgs from "./kubectl/createArgs.mdx"
 import PartialKubectlBinaryPath from "./kubectl/kubectlBinaryPath.mdx"
 import PartialInlineManifest from "./kubectl/inlineManifest.mdx"
 import PartialGroupkustomize from "./kubectl/group_kustomize.mdx"
+import PartialGroupmodifications from "./kubectl/group_modifications.mdx"
 
 <PartialManifests />
 
@@ -22,3 +23,6 @@ import PartialGroupkustomize from "./kubectl/group_kustomize.mdx"
 
 
 <PartialGroupkustomize />
+
+
+<PartialGroupmodifications />

--- a/docs/pages/configuration/deployments/kubectl/README.mdx
+++ b/docs/pages/configuration/deployments/kubectl/README.mdx
@@ -7,8 +7,9 @@ import ConfigPartial from '../../_partials/v2beta1/deployments/kubectl.mdx'
 
 
 DevSpace supports two types of deployments aside from Helm charts:
-- [`Kubernetes manifests`](./manifests.mdx) (think `kubectl apply -f manifest.yaml`)
-- [`Kubernetes inline manifests`](./inline_manifests.mdx) (think `kubectl apply -f manifest.yaml`)
+- [`Manifests`](./manifests.mdx):
+  - [`Kubernetes file manifests`](./manifests.mdx) (think `kubectl apply -f manifest.yaml`)
+  - [`Kubernetes inline manifests`](./inline_manifests.mdx) (think `kubectl apply -f manifest.yaml`)
 - [`Kustomizations`](./kustomizations.mdx) (think `kubectl apply -k kustomization/`)
 
 

--- a/docs/pages/configuration/deployments/kubectl/patches.mdx
+++ b/docs/pages/configuration/deployments/kubectl/patches.mdx
@@ -1,0 +1,218 @@
+---
+title: "Manifests: Patches"
+sidebar_label: Patches
+---
+
+import ConfigPartialCommands from '../../_partials/v2beta1/deployments/kubectl/patches.mdx'
+
+Patches are a way to perform minor overrides to the configuration without having to create a separate config file. Patch functionality follows JSON Patch([RFC](https://tools.ietf.org/html/rfc6902)) semantics, as well as enhanced `path` selectors, as implemented by the [yaml-jsonpath](https://github.com/vmware-labs/yaml-jsonpath) library.
+
+Patches are compatible with [kubectl manifests](./manifests.mdx) and [inlineManifest](./inline_manifests.mdx).
+
+## Example
+Patches are ideal for reflecting changes between different environments, e.g. dev, staging and production.
+```yaml {9-17}
+version: v2beta1
+name: nginx-k8s
+
+deployments:
+  example:
+    kubectl:
+      manifests:
+        - ./deployment.yaml
+      patches:
+        - target:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: nginx-deployment
+          op: replace
+          path: spec.template.spec.containers[0].image
+          value: nginx:1.23.3
+```
+**Explanation:**  
+- The above example defines 1 patch for the `deployment.yaml` manifest
+- During deployment, the patches are applied in-memory, changing in this case the image of the container
+
+```yaml {18}
+# In-Memory deployment BEFORE Applying Patches 
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+```
+
+```yaml {18}
+# In-Memory deployment AFTER Applying Patches 
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.23.3
+          ports:
+            - containerPort: 80
+```
+
+:::tip Array Paths
+When you want to define a `path` that contains an array (e.g. `containers`), you have several options:
+
+1. Use the index of the array item you want to patch, e.g. `spec.template.spec.containers[0]`, `spec.template.spec.containers/0`
+2. Use a wildcard selector to match all array item(s), e.g. `spec.template.spec.containers.*`,`spec.template.spec.containers[*]` or `spec.template.spec.containers/*`
+
+:::
+
+:::info Value For Replace / Add
+If you use the `replace` or `add` operation, `value` is a mandatory property.
+:::
+
+:::info
+If `value` is defined, the new value must provide the correct type to be used when adding or replacing the existing value found under `path` using the newly provided `value`, e.g. an array must be replaced with an array.
+:::
+
+#### Example: Match patches
+```yaml {35-43}
+version: v2beta1
+name: nginx-k8s
+
+deployments:
+  example:
+    kubectl:
+      inlineManifest: |-
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: nginx-inline-deployment
+        spec:
+          selector:
+            matchLabels:
+              app: nginx
+          replicas: 4
+          template:
+            metadata:
+              labels:
+                app: nginx
+            spec:
+              containers:
+                - name: nginx
+                  image: nginx:1.14.2
+                  ports:
+                    - containerPort: 80
+                - name: busybox
+                  image: busybox
+                  command: ["sleep"]
+                  args: ["infinity"]
+                - name: alpine
+                  image: alpine
+                  command: ["sleep"]
+                  args: ["infinity"]
+      patches:
+        # wildcard match
+        - target:
+            apiVersion: apps/v1 # Optional
+            kind: Deployment    # Optional
+            name: nginx-inline-deployment # Required
+          op: add
+          path: spec.template.spec.containers[*].env
+          value: [{"name": "test", "value": "test123"}]
+```
+**Explanation:**  
+- The above example will patch and add an environment variable `test=test123` to all containers in the deployment.
+
+#### Example: Using target effectively
+```yaml {9,29,42-43,49-50}
+version: v2beta1
+name: nginx-k8s
+
+deployments:
+  example:
+    kubectl:
+      inlineManifest: |-
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: nginx-inline-deployment
+        spec:
+          selector:
+            matchLabels:
+              app: nginx
+          replicas: 4
+          template:
+            metadata:
+              labels:
+                app: nginx
+            spec:
+              containers:
+                - name: nginx
+                  image: nginx:1.14.2
+                  ports:
+                    - containerPort: 80
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: nginx-inline-deployment
+          labels:
+            app: nginx-inline-deployment
+        spec:
+          ports:
+          - port: 80
+            protocol: TCP
+          selector:
+            app: nginx-inline-deployment
+      patch:
+        - target:
+            apiVersion: apps/v1         # Optional
+            kind: Deployment    # Optional
+            name: nginx-inline-deployment # Required
+          op: add
+          path: spec.template.metadata.labels.test
+          value: test-deployment
+        - target:
+            apiVersion: v1 # Optional
+            kind: Service    # Optional
+            name: nginx-inline-deployment # Required
+          op: add
+          path: metadata.labels.test
+          value: test-service
+```
+
+**Explanation:**
+- The above example shows how you can address two resources with the same name, in this case `nginx-inline-deployment`.
+- By using `kind` and `apiVersion` we can narrow down one patch to be applied only on `apps/v1 - Deployment` and the other only to `v1 - Service`
+
+## Configuration
+
+<ConfigPartialCommands/>
+
+
+<br/>
+
+
+
+<FragmentInfoPrintConfig/>

--- a/docs/schemas/config-openapi.json
+++ b/docs/schemas/config-openapi.json
@@ -753,12 +753,15 @@
                 "type": "array",
                 "description": "TemplateArgs are additional arguments to pass to `helm template`"
               },
-              "disableDependencyUpdate" : {
+              "disableDependencyUpdate": {
                 "type": "boolean",
-                "description" : "DisableDependencyUpdate disables helm dependencies update"
+                "description": "DisableDependencyUpdate disables helm dependencies update, default to false"
               }
             },
             "type": "object",
+            "required": [
+              "disableDependencyUpdate"
+            ],
             "description": "HelmConfig defines the specific helm options used during deployment"
           },
           "Image": {
@@ -1196,7 +1199,7 @@
               },
               "inlineManifest": {
                 "type": "string",
-                "description": "InlineManists is a block containing the manifest to deploy"
+                "description": "InlineManifests is a block containing the manifest to deploy"
               },
               "kustomize": {
                 "type": "boolean",
@@ -1216,6 +1219,14 @@
                 "type": "string",
                 "description": "KustomizeBinaryPath is the optional path where to find the kustomize binary",
                 "group": "kustomize"
+              },
+              "patches": {
+                "items": {
+                  "$ref": "#/definitions/Config/$defs/PatchTarget"
+                },
+                "type": "array",
+                "description": "Patches are additional changes to the pod spec that should be applied",
+                "group": "modifications"
               }
             },
             "type": "object",
@@ -1316,6 +1327,32 @@
               "path"
             ],
             "description": "PatchConfig describes a config patch and how it should be applied"
+          },
+          "PatchTarget": {
+            "properties": {
+              "target": {
+                "$ref": "#/definitions/Config/$defs/Target",
+                "description": "Target describes where to apply a config patch"
+              },
+              "op": {
+                "type": "string",
+                "description": "Operation is the path operation to do. Can be either replace, add or remove"
+              },
+              "path": {
+                "type": "string",
+                "description": "Path is the config path to apply the patch to"
+              },
+              "value": {
+                "description": "Value is the value to use for this patch."
+              }
+            },
+            "type": "object",
+            "required": [
+              "target",
+              "op",
+              "path"
+            ],
+            "description": "PatchTarget describes a config patch and how it should be applied"
           },
           "PersistenceOptions": {
             "properties": {
@@ -1817,6 +1854,29 @@
             },
             "type": "object",
             "description": "SyncOnUpload defines the struct for the command that should be executed when files / folders are uploaded"
+          },
+          "Target": {
+            "properties": {
+              "apiVersion": {
+                "type": "string",
+                "description": "ApiVersion is the Kubernetes api of the target resource"
+              },
+              "kind": {
+                "type": "string",
+                "description": "Kind is the kind of the target resource (eg: Deployment, Service ...)"
+              },
+              "name": {
+                "type": "string",
+                "description": "Name is the name of the target resource"
+              }
+            },
+            "type": "object",
+            "required": [
+              "apiVersion",
+              "kind",
+              "name"
+            ],
+            "description": "Target describes where to apply a config patch"
           },
           "Terminal": {
             "properties": {

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -89,8 +89,17 @@ module.exports = {
               collapsible: false,
               link: { type: 'doc', id: 'configuration/deployments/kubectl/README' },
               items: [
-                'configuration/deployments/kubectl/manifests',
-                'configuration/deployments/kubectl/inline_manifests',
+                {
+                  type: 'category',
+                  label: 'Manifests',
+                  collapsible: false,
+                  link: { type: 'doc', id: 'configuration/deployments/kubectl/README' },
+                  items: [
+                    'configuration/deployments/kubectl/manifests',
+                    'configuration/deployments/kubectl/inline_manifests',
+                    'configuration/deployments/kubectl/patches',
+                  ],
+                },
                 'configuration/deployments/kubectl/kustomizations',
               ],
             },

--- a/e2e/tests/deploy/testdata/kubectl_inline_manifest_patches/devspace.yaml
+++ b/e2e/tests/deploy/testdata/kubectl_inline_manifest_patches/devspace.yaml
@@ -1,0 +1,91 @@
+version: v2beta1
+name: nginx-k8s
+
+deployments:
+  example:
+    kubectl:
+      inlineManifest: |-
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: nginx-inline-deployment
+        spec:
+          selector:
+            matchLabels:
+              app: nginx
+          replicas: 4
+          template:
+            metadata:
+              labels:
+                app: nginx
+            spec:
+              containers:
+                - name: nginx
+                  image: nginx:1.14.2
+                  ports:
+                    - containerPort: 80
+                - name: busybox
+                  image: busybox
+                  command: ["sleep"]
+                  args: ["infinity"]
+                - name: alpine
+                  image: alpine
+                  command: ["sleep"]
+                  args: ["infinity"]
+        ---
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: nginx-inline-deployment
+          labels:
+            app: nginx-inline-deployment
+        spec:
+          ports:
+          - port: 80
+            protocol: TCP
+          selector:
+            app: nginx-inline-deployment
+
+      patches:
+        - target:
+            apiVersion: apps/v1 # Optional
+            kind: Deployment    # Optional
+            name: nginx-inline-deployment # Required
+          op: replace
+          path: spec.template.spec.containers[0].image
+          value: nginx:1.23.3
+        - target:
+            apiVersion: apps/v1         # Optional
+            kind: Deployment    # Optional
+            name: nginx-inline-deployment # Required
+          op: remove
+          path: spec.replicas
+        - target:
+            apiVersion: apps/v1         # Optional
+            kind: Deployment    # Optional
+            name: nginx-inline-deployment # Required
+          op: add
+          path: spec.template.metadata.labels.test
+          value: test123
+        - target:
+            apiVersion: v1 # Optional
+            kind: Service    # Optional
+            name: nginx-inline-deployment # Required
+          op: replace
+          path: spec.ports[0].port
+          value: 8080
+        - target:
+            apiVersion: v1 # Optional
+            kind: Service    # Optional
+            name: nginx-inline-deployment # Required
+          op: add
+          path: metadata.labels.test
+          value: test234
+        # wildcard match
+        - target:
+            apiVersion: apps/v1 # Optional
+            kind: Deployment    # Optional
+            name: nginx-inline-deployment # Required
+          op: add
+          path: spec.template.spec.containers[*].env
+          value: [{"name": "test", "value": "test123"}]

--- a/e2e/tests/deploy/testdata/kubectl_patches/deployment.yaml
+++ b/e2e/tests/deploy/testdata/kubectl_patches/deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 4
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80
+        - name: busybox
+          image: busybox
+          command: ["sleep"]
+          args: ["infinity"]
+        - name: alpine
+          image: alpine
+          command: ["sleep"]
+          args: ["infinity"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx-deployment
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+  selector:
+    app: nginx-deployment

--- a/e2e/tests/deploy/testdata/kubectl_patches/devspace.yaml
+++ b/e2e/tests/deploy/testdata/kubectl_patches/devspace.yaml
@@ -1,0 +1,52 @@
+version: v2beta1
+name: nginx-k8s
+
+deployments:
+  example:
+    kubectl:
+      manifests:
+        - ./deployment.yaml
+      patches:
+        # match specific container
+        - target:
+            apiVersion: apps/v1 # Optional
+            kind: Deployment    # Optional
+            name: nginx-deployment # Required
+          op: replace
+          path: spec.template.spec.containers[0].image
+          value: nginx:1.23.3
+        - target:
+            apiVersion: apps/v1         # Optional
+            kind: Deployment    # Optional
+            name: nginx-deployment # Required
+          op: remove
+          path: spec.replicas
+        - target:
+            apiVersion: apps/v1         # Optional
+            kind: Deployment    # Optional
+            name: nginx-deployment # Required
+          op: add
+          path: spec.template.metadata.labels.test
+          value: test123
+        - target:
+            apiVersion: v1 # Optional
+            kind: Service    # Optional
+            name: nginx-deployment # Required
+          op: replace
+          path: spec.ports[0].port
+          value: 8080
+        - target:
+            apiVersion: v1 # Optional
+            kind: Service    # Optional
+            name: nginx-deployment # Required
+          op: add
+          path: metadata.labels.test
+          value: test234
+        # wildcard match
+        - target:
+            apiVersion: apps/v1 # Optional
+            kind: Deployment    # Optional
+            name: nginx-deployment # Required
+          op: add
+          path: spec.template.spec.containers[*].env
+          value: [{"name": "test", "value": "test123"}]

--- a/pkg/devspace/config/loader/patch/patch.go
+++ b/pkg/devspace/config/loader/patch/patch.go
@@ -2,6 +2,9 @@ package patch
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/loft-sh/devspace/pkg/util/yamlutil"
 
 	"gopkg.in/yaml.v3"
@@ -40,4 +43,45 @@ func NewNode(raw *interface{}) (*yaml.Node, error) {
 	}
 
 	return &node, nil
+}
+
+func TransformPath(path string) string {
+	if path == "" {
+		return path
+	}
+
+	legacyExtendedSyntaxRegEx := regexp.MustCompile(`(?i)([^\=]+)=([^\.\=\>\<\~]+)`)
+	hasFilterRegEx := regexp.MustCompile(`(?i)\[\?.*\)\]`)
+	indexXPathRegEx := regexp.MustCompile(`\/(\d+|\*)\/`)
+	trailingIndexXPathRegEx := regexp.MustCompile(`\/(\d+|\*)$`)
+	rootXPathRegEx := regexp.MustCompile(`^\/`)
+	numeric := regexp.MustCompile(`^\d+$`)
+	rewrittenPath := path
+
+	if legacyExtendedSyntaxRegEx.MatchString(path) {
+		// Using property=value selectors
+		rewriteTokens := []string{}
+		tokens := strings.Split(path, ".")
+		for _, token := range tokens {
+			rewriteToken := token
+			if legacyExtendedSyntaxRegEx.MatchString(token) {
+				filterTokens := legacyExtendedSyntaxRegEx.FindStringSubmatch(token)
+				if numeric.MatchString((filterTokens[2])) {
+					rewriteToken = fmt.Sprintf("[?(@.%s=='%s' || @.%s==%s)]", filterTokens[1], filterTokens[2], filterTokens[1], filterTokens[2])
+				} else {
+					rewriteToken = fmt.Sprintf("[?(@.%s=='%s')]", filterTokens[1], filterTokens[2])
+				}
+			}
+			rewriteTokens = append(rewriteTokens, rewriteToken)
+		}
+		rewrittenPath = strings.Join(rewriteTokens, ".")
+		rewrittenPath = strings.ReplaceAll(rewrittenPath, ".[?", "[?")
+	} else if strings.Contains(path, "/") && !hasFilterRegEx.MatchString(path) {
+		// Is XPath
+		rewrittenPath = indexXPathRegEx.ReplaceAllString(path, "[$1].")
+		rewrittenPath = trailingIndexXPathRegEx.ReplaceAllString(rewrittenPath, "[$1]")
+		rewrittenPath = rootXPathRegEx.ReplaceAllLiteralString(rewrittenPath, "$.")
+	}
+
+	return rewrittenPath
 }

--- a/pkg/devspace/config/loader/patch/path_test.go
+++ b/pkg/devspace/config/loader/patch/path_test.go
@@ -67,3 +67,35 @@ func TestGetParentPath(t *testing.T) {
 		}
 	}
 }
+
+func TestTransformPath(t *testing.T) {
+	testCases := map[string]string{
+		"$.dev": "$.dev",
+		".dev":  ".dev",
+		"dev":   "dev",
+		"deployments.name=backend.helm.values.containers":            "deployments[?(@.name=='backend')].helm.values.containers",
+		"deployments.name=backend.helm.values.containers.name=proxy": "deployments[?(@.name=='backend')].helm.values.containers[?(@.name=='proxy')]",
+		"/deployments/0":                                     "$.deployments[0]",
+		"deployments/0":                                      "deployments[0]",
+		"deployments/0/containers/1":                         "deployments[0].containers[1]",
+		"deployments.*.containers.*":                         "deployments.*.containers.*",
+		"deployments/*/containers/*":                         "deployments[*].containers[*]",
+		"deployments/0/containers/1/name":                    "deployments[0].containers[1].name",
+		"deployments/*/containers/*/name":                    "deployments[*].containers[*].name",
+		"deployments.name=test2":                             "deployments[?(@.name=='test2')]",
+		"deployments.name=backend.helm.values.containers[1]": "deployments[?(@.name=='backend')].helm.values.containers[1]",
+		`deployments[?(@.name=='staging1')]`:                 `deployments[?(@.name=='staging1')]`,
+		`deployments[?(@.helm.timeout > 1000)]`:              `deployments[?(@.helm.timeout > 1000)]`,
+		`deployments.name=backend.helm.values.containers.image=john/devbackend.image`: `deployments[?(@.name=='backend')].helm.values.containers[?(@.image=='john/devbackend')].image`,
+		`dev.ports.name=rails.reverseForward.port=9200`:                               `dev.ports[?(@.name=='rails')].reverseForward[?(@.port=='9200' || @.port==9200)]`,
+	}
+
+	// Run test cases
+	for in, expected := range testCases {
+		actual := TransformPath(in)
+
+		if actual != expected {
+			t.Errorf("TestCase %s: Got\n%s, but expected\n%s", in, actual, expected)
+		}
+	}
+}

--- a/pkg/devspace/config/loader/profile_test.go
+++ b/pkg/devspace/config/loader/profile_test.go
@@ -8,38 +8,6 @@ import (
 	yaml "gopkg.in/yaml.v3"
 )
 
-func TestTransformPath(t *testing.T) {
-	testCases := map[string]string{
-		"$.dev": "$.dev",
-		".dev":  ".dev",
-		"dev":   "dev",
-		"deployments.name=backend.helm.values.containers":            "deployments[?(@.name=='backend')].helm.values.containers",
-		"deployments.name=backend.helm.values.containers.name=proxy": "deployments[?(@.name=='backend')].helm.values.containers[?(@.name=='proxy')]",
-		"/deployments/0":                                     "$.deployments[0]",
-		"deployments/0":                                      "deployments[0]",
-		"deployments/0/containers/1":                         "deployments[0].containers[1]",
-		"deployments.*.containers.*":                         "deployments.*.containers.*",
-		"deployments/*/containers/*":                         "deployments[*].containers[*]",
-		"deployments/0/containers/1/name":                    "deployments[0].containers[1].name",
-		"deployments/*/containers/*/name":                    "deployments[*].containers[*].name",
-		"deployments.name=test2":                             "deployments[?(@.name=='test2')]",
-		"deployments.name=backend.helm.values.containers[1]": "deployments[?(@.name=='backend')].helm.values.containers[1]",
-		`deployments[?(@.name=='staging1')]`:                 `deployments[?(@.name=='staging1')]`,
-		`deployments[?(@.helm.timeout > 1000)]`:              `deployments[?(@.helm.timeout > 1000)]`,
-		`deployments.name=backend.helm.values.containers.image=john/devbackend.image`: `deployments[?(@.name=='backend')].helm.values.containers[?(@.image=='john/devbackend')].image`,
-		`dev.ports.name=rails.reverseForward.port=9200`:                               `dev.ports[?(@.name=='rails')].reverseForward[?(@.port=='9200' || @.port==9200)]`,
-	}
-
-	// Run test cases
-	for in, expected := range testCases {
-		actual := transformPath(in)
-
-		if actual != expected {
-			t.Errorf("TestCase %s: Got\n%s, but expected\n%s", in, actual, expected)
-		}
-	}
-}
-
 type testCase struct {
 	in       map[string]interface{}
 	expected map[string]interface{}

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1717,15 +1717,19 @@ type ProfileActivation struct {
 
 // PatchTarget describes a config patch and how it should be applied
 type PatchTarget struct {
-	Target      `yaml:"target" json:"target"`
+	// Target describes where to apply a config patch
+	Target      Target `yaml:"target" json:"target"`
 	PatchConfig `yaml:",inline" json:",inline"`
 }
 
 // Target describes where to apply a config patch
 type Target struct {
+	// ApiVersion is the Kubernetes api of the target resource
 	APIVersion string `yaml:"apiVersion" json:"apiVersion,omitempty"`
-	Kind    string `yaml:"kind" json:"kind,omitempty"`
-	Name    string `yaml:"name" json:"name"  jsonschema:"required"`
+	// Kind is the kind of the target resource (eg: Deployment, Service ...)
+	Kind string `yaml:"kind" json:"kind,omitempty"`
+	// Name is the name of the target resource
+	Name string `yaml:"name" json:"name"  jsonschema:"required"`
 }
 
 // PatchConfig describes a config patch and how it should be applied

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -882,6 +882,9 @@ type KubectlConfig struct {
 	KustomizeArgs []string `yaml:"kustomizeArgs,omitempty" json:"kustomizeArgs,omitempty" jsonschema_extras:"group=kustomize"`
 	// KustomizeBinaryPath is the optional path where to find the kustomize binary
 	KustomizeBinaryPath string `yaml:"kustomizeBinaryPath,omitempty" json:"kustomizeBinaryPath,omitempty" jsonschema_extras:"group=kustomize"`
+
+	// Patches are additional changes to the pod spec that should be applied
+	Patches []*PatchTarget `yaml:"patches,omitempty" json:"patches,omitempty" jsonschema_extras:"group=modifications"`
 }
 
 // DevPod holds configurations for selecting a pod and starting dev services for that pod
@@ -1710,6 +1713,19 @@ type ProfileActivation struct {
 	// Vars defines key/value pairs where the key is the name of the variable and the value is a regular expression used to match the variable's value.
 	// When multiple keys are specified, they must all evaluate to true to activate the profile.
 	Vars map[string]string `yaml:"vars,omitempty" json:"vars,omitempty"`
+}
+
+// PatchTarget describes a config patch and how it should be applied
+type PatchTarget struct {
+	Target      `yaml:"target" json:"target"`
+	PatchConfig `yaml:",inline" json:",inline"`
+}
+
+// Target describes where to apply a config patch
+type Target struct {
+	APIVersion string `yaml:"apiVersion" json:"apiVersion,omitempty"`
+	Kind    string `yaml:"kind" json:"kind,omitempty"`
+	Name    string `yaml:"name" json:"name"  jsonschema:"required"`
 }
 
 // PatchConfig describes a config patch and how it should be applied

--- a/pkg/devspace/config/versions/validate.go
+++ b/pkg/devspace/config/versions/validate.go
@@ -269,7 +269,7 @@ func validateDeployments(config *latest.Config) error {
 		}
 		if deployConfig.Kubectl != nil && deployConfig.Kubectl.Patches != nil {
 			for patch := range deployConfig.Kubectl.Patches {
-				if deployConfig.Kubectl.Patches[patch].Name == "" {
+				if deployConfig.Kubectl.Patches[patch].Target.Name == "" {
 					return errors.Errorf("deployments[%s].kubectl.patches[%d].target.name is required", index, patch)
 				}
 				if deployConfig.Kubectl.Patches[patch].Operation == "" {

--- a/pkg/devspace/config/versions/validate.go
+++ b/pkg/devspace/config/versions/validate.go
@@ -267,6 +267,23 @@ func validateDeployments(config *latest.Config) error {
 		if deployConfig.Kubectl != nil && deployConfig.Helm != nil {
 			return errors.Errorf("deployments[%s].kubectl and deployments[%s].helm cannot be used together", index, index)
 		}
+		if deployConfig.Kubectl != nil && deployConfig.Kubectl.Patches != nil {
+			for patch := range deployConfig.Kubectl.Patches {
+				if deployConfig.Kubectl.Patches[patch].Name == "" {
+					return errors.Errorf("deployments[%s].kubectl.patches[%d].target.name is required", index, patch)
+				}
+				if deployConfig.Kubectl.Patches[patch].Operation == "" {
+					return errors.Errorf("deployments[%s].kubectl.patches[%d].op is required", index, patch)
+				}
+				if deployConfig.Kubectl.Patches[patch].Path == "" {
+					return errors.Errorf("deployments[%s].kubectl.patches[%d].path is required", index, patch)
+				}
+				if deployConfig.Kubectl.Patches[patch].Operation != "remove" &&
+					deployConfig.Kubectl.Patches[patch].Value == nil {
+					return errors.Errorf("deployments[%s].kubectl.patches[%d].value is required", index, patch)
+				}
+			}
+		}
 	}
 
 	return nil

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl.go
@@ -359,7 +359,7 @@ func (d *DeployConfig) applyDeployPatches(ctx devspacecontext.Context, resource 
 			Path: patch.OpPath(patch.TransformPath(kubepatch.Path)),
 		}
 
-		if kubepatch.Name != resource.GetName() {
+		if kubepatch.Target.Name != resource.GetName() {
 			continue
 		}
 
@@ -384,7 +384,7 @@ func (d *DeployConfig) applyDeployPatches(ctx devspacecontext.Context, resource 
 		}
 
 		// TODO Maybe log here that we're indeed applying a patch?
-		ctx.Log().Debugf("applying patch: %s.%s", kubepatch.Name, kubepatch.Path)
+		ctx.Log().Debugf("applying patch: %s.%s", kubepatch.Target.Name, kubepatch.Path)
 		patches = append(patches, newPatch)
 	}
 

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl.go
@@ -3,7 +3,6 @@ package kubectl
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -11,6 +10,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/config/constants"
 	"mvdan.cc/sh/v3/expand"
 
+	"github.com/loft-sh/devspace/pkg/devspace/config/loader/patch"
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable/legacy"
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable/runtime"
 	"github.com/loft-sh/devspace/pkg/devspace/config/remotecache"
@@ -264,6 +264,7 @@ func (d *DeployConfig) getReplacedManifest(ctx devspacecontext.Context, inline b
 		if resource.Object == nil {
 			continue
 		}
+
 		if resource.GetNamespace() == "" {
 			resource.SetNamespace(d.Namespace)
 		}
@@ -282,6 +283,12 @@ func (d *DeployConfig) getReplacedManifest(ctx devspacecontext.Context, inline b
 			} else if redeploy {
 				shouldRedeploy = true
 			}
+		}
+
+		resource, err := d.applyDeployPatches(ctx, resource)
+		if err != nil {
+			// we're skipping a patch
+			ctx.Log().Warn(err)
 		}
 
 		replacedManifest, err := yaml.Marshal(resource)
@@ -323,7 +330,7 @@ func (d *DeployConfig) buildManifests(ctx devspacecontext.Context, manifest stri
 
 	raw, err := ctx.KubeClient().KubeConfigLoader().LoadRawConfig()
 	if err != nil {
-		return nil, fmt.Errorf("get raw config")
+		return nil, errors.Errorf("get raw config")
 	}
 	copied := raw.DeepCopy()
 	for key := range copied.Contexts {
@@ -337,4 +344,61 @@ func (d *DeployConfig) buildManifests(ctx devspacecontext.Context, manifest stri
 func (d *DeployConfig) isKustomizeInstalled(ctx context.Context, dir, path string) bool {
 	err := command.Command(ctx, dir, expand.ListEnviron(os.Environ()...), nil, nil, nil, path, "version")
 	return err == nil
+}
+
+func (d *DeployConfig) applyDeployPatches(ctx devspacecontext.Context, resource *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+	out, err := yaml.Marshal(resource)
+	if err != nil {
+		return resource, err
+	}
+
+	patches := patch.Patch{}
+	for idx, kubepatch := range d.DeploymentConfig.Kubectl.Patches {
+		newPatch := patch.Operation{
+			Op:   patch.Op(kubepatch.Operation),
+			Path: patch.OpPath(patch.TransformPath(kubepatch.Path)),
+		}
+
+		if kubepatch.Name != resource.GetName() {
+			continue
+		}
+
+		// non-mandatory field, check only if defined
+		if kubepatch.Target.Kind != "" && resource.GetKind() != kubepatch.Target.Kind {
+			ctx.Log().Debugf("skipping patch, resource kind match: %s - %s", kubepatch.Target.Kind, resource.GetKind())
+			continue
+		}
+
+		// non-mandatory field, check only if defined
+		if kubepatch.Target.APIVersion != "" && resource.GetAPIVersion() != kubepatch.Target.APIVersion {
+			ctx.Log().Debugf("skipping patch, resource api mismatch: %s - %s", kubepatch.Target.APIVersion, resource.GetAPIVersion())
+			continue
+		}
+
+		if kubepatch.Value != nil {
+			value, err := patch.NewNode(&kubepatch.Value)
+			if err != nil {
+				return resource, errors.Errorf("value %d is invalid", idx)
+			}
+			newPatch.Value = value
+		}
+
+		// TODO Maybe log here that we're indeed applying a patch?
+		ctx.Log().Debugf("applying patch: %s.%s", kubepatch.Name, kubepatch.Path)
+		patches = append(patches, newPatch)
+	}
+
+	out, err = patches.Apply(out)
+	if err != nil {
+		return resource, errors.Wrap(err, "apply patches")
+	}
+
+	// transform resource back to unstructured
+	var result unstructured.Unstructured
+	err = yaml.Unmarshal(out, &result)
+	if err != nil {
+		return nil, err
+	}
+
+	return &result, nil
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #1678
Closes ENG-249

**Please provide a short message that should be published in the DevSpace release notes**
This PR adds support for patches also in kubectl deployments.
It supports both normal and inlineManifests

Works like the profile patches, so `add`, `remove`, `replace` operations are supported
Wildcards are supported

Example yaml:

```yaml
version: v2beta1
name: nginx-k8s

deployments:
  example:
    kubectl:
      inlineManifest: |-
        apiVersion: apps/v1
        kind: Deployment
        metadata:
          name: nginx-deployment
        spec:
          selector:
            matchLabels:
              app: nginx
          replicas: 4
          template:
            metadata:
              labels:
                app: nginx
            spec:
              containers:
                - name: nginx
                  image: nginx:1.14.2
                  ports:
                    - containerPort: 80
      patches:
        - target:
            apiVersion: apps/v1 # Optional
            kind: Deployment    # Optional
            name: nginx-deployment # Required
          op: replace
          path: spec.template.spec.containers[0].image
          value: nginx:1.23.3
```

