### PR TITLE
fix: add implicit patch during dev to unset readOnlyRootFilesystem when sync is enabled

### DIFF
--- a/docs/pages/cli/devspace_list_ports.md
+++ b/docs/pages/cli/devspace_list_ports.md
@@ -25,7 +25,8 @@ Lists the port forwarding configurations
 ## Flags
 
 ```
-  -h, --help   help for ports
+  -h, --help            help for ports
+  -o, --output string   The output format of the command. Can be either empty or json
 ```
 
 

--- a/docs/pages/configuration/dev/modifications/patches.mdx
+++ b/docs/pages/configuration/dev/modifications/patches.mdx
@@ -62,7 +62,8 @@ DevSpace adds certain modifications and patches in-memory if certain conditions 
   <tr>
 <td>
 
-`terminal` enabled
+`terminal` enabled or  
+`attach` enabled
 
 </td>
 <td>
@@ -83,6 +84,24 @@ dev:
 
 </td>
   </tr>
+<td>
+
+`sync` enabled
+
+</td>
+<td>
+
+```yaml title=devspace.yaml
+dev:
+  $name:
+    command: ["sleep"]
+    args: ["1000000000"]
+    patches:
+    - op: remove
+      path: spec.containers[].securityContext.readOnlyRootFilesystem
+```
+
+</td>
 </tbody>
 </table>
 


### PR DESCRIPTION
Sync may not work if the container SecurityContext enables ReadOnlyRootFilesystem.
So let's do an Implicit Patch to remove this, and leave user's `devspace.yaml` less cluttered

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2572 
Closes ENG-1055