### PR TITLE
ci: add job to detect PRs that need docs update

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
 
-  check-changes:
+  check_changes:
     runs-on: ubuntu-latest
     outputs:
       docs_changes: ${{ steps.check_file_changed.outputs.changed }}

--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -1,0 +1,45 @@
+name: Check Docs
+
+on:
+  pull_request:
+
+jobs:
+
+  check-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_changes: ${{ steps.check_file_changed.outputs.changed }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # Checkout as many commits as needed for the diff
+          fetch-depth: 2
+
+      # Generate docs
+      # Return true/false if docs are changed
+      - id: check_file_changed
+        run: |
+          ./gendocs.sh
+          if git diff --name-only | grep -E "^docs|devspace-schema.json"; then
+            echo "{changed}={True}" >> $GITHUB_OUTPUT
+          else
+            echo "{changed}={False}" >> $GITHUB_OUTPUT
+          fi
+
+
+
+  check-docs:
+    runs-on: ubuntu-latest
+    needs: check_changes
+    if: needs.check_changes.outputs.docs_changes == 'True'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: mshick/add-pr-comment@v2
+        with:
+          allow-repeats: true
+          message: |
+            **Docs Update Needed!**
+            It seems like you need to run `gendocs.sh` in order to update the docs.
+            Please run this command and commit before merging.
+            Thanks!

--- a/gendocs.sh
+++ b/gendocs.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+set -o errexit
+set -o nounset
+
+go run ./docs/hack/cli/main.go
+go run ./docs/hack/config/partials/main.go
+go run ./docs/hack/config/schemas/main.go


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Closes ENG-1030

This will add a new Github Action that will check if we need to update auto-generated docs.
The action will simply run the `gendocs.sh` script, and if changes are detected, we inform the users in the PR using
a bot message.

Here is an example:

![image](https://user-images.githubusercontent.com/598882/222098420-c3ea0de8-9d27-41e7-afa1-0534eba403d6.png)
