### PR TITLE
fix: make restart script compatible with non-GNU userlands

### DIFF
--- a/e2e/tests/replacepods/replacepods.go
+++ b/e2e/tests/replacepods/replacepods.go
@@ -68,20 +68,20 @@ var _ = DevSpaceDescribe("replacepods", func() {
 		}()
 
 		// check if file is there
-		framework.ExpectRemoteFileContents("ubuntu", ns, "/app/test2.txt", "Hello World 123")
+		framework.ExpectRemoteFileContents("alpine", ns, "/app/test2.txt", "Hello World 123")
 
 		// check if file is there
-		framework.ExpectRemoteFileContents("ubuntu", ns, "/test.txt", "Hello World\n")
+		framework.ExpectRemoteFileContents("alpine", ns, "/test.txt", "Hello World\n")
 
 		// upload a file and restart the container
 		err = os.WriteFile("test1.txt", []byte("Hello World2!"), 0777)
 		framework.ExpectNoError(err)
 
 		// wait for uploaded
-		framework.ExpectRemoteFileContents("ubuntu", ns, "/app/test1.txt", "Hello World2!")
+		framework.ExpectRemoteFileContents("alpine", ns, "/app/test1.txt", "Hello World2!")
 
 		// wait for restarted
-		framework.ExpectRemoteFileContents("ubuntu", ns, "/test.txt", "Hello World\nHello World\n")
+		framework.ExpectRemoteFileContents("alpine", ns, "/test.txt", "Hello World\nHello World\n")
 
 		cancel()
 		err = <-done

--- a/e2e/tests/replacepods/testdata/restart-helper/devspace.yaml
+++ b/e2e/tests/replacepods/testdata/restart-helper/devspace.yaml
@@ -4,9 +4,9 @@ name: attach
 pipelines:
   dev:
     run: |-
-      create_deployments test --set helm.values.containers[0].image=ubuntu
-      
-      start_dev test --set imageSelector=ubuntu \
+      create_deployments test --set helm.values.containers[0].image=alpine
+
+      start_dev test --set imageSelector=alpine \
                      --set 'command={sh,-c,echo Hello World >> /test.txt; sleep 100000}' \
                      --set logs.enabled=true \
                      --set sync[0].path=.:/app \


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2571 
Closes ENG=1053

With these workarounds, we get the same effect of `tail --pid` but we fix compatibility with non-GNU userlands, where non-standard flags are unsupported.

Also switch the e2e test to alpine, in order to cover this type of use-case