### PR TITLE
fix: exclude node_modules during devspace init by default

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -737,6 +737,10 @@ func (cmd *InitCmd) addDevConfig(config *latest.Config, imageName, image string,
 		Path: "./",
 	}
 
+	if _, err := os.Stat("node_modules"); err == nil {
+		syncConfig.UploadExcludePaths = append(syncConfig.UploadExcludePaths, "node_modules")
+	}
+
 	if _, err := os.Stat(".dockerignore"); err == nil {
 		syncConfig.UploadExcludeFile = ".dockerignore"
 	}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2587
fixes ENG-1069

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace init is syncing `node_modules` by default, which modifies permissions and prevents locally installed CLI modules from working correctly

**What else do we need to know?** 
While not necessarily a bug, this could trip up many first-time users who are not aware that excluding `node_modules` from syncing is usually a good idea.