### PR TITLE
Combine stdout and stderr when getting version from requried commands

### DIFF
--- a/pkg/devspace/config/loader/loader.go
+++ b/pkg/devspace/config/loader/loader.go
@@ -269,7 +269,7 @@ func (l *configLoader) ensureRequires(ctx context.Context, config *latest.Config
 			return errors.Wrapf(err, "parsing require.commands[%d].version", index)
 		}
 
-		out, err := command.Output(ctx, filepath.Dir(l.absConfigPath), expand.ListEnviron(os.Environ()...), c.Name, versionArgs...)
+		out, err := command.CombinedOutput(ctx, filepath.Dir(l.absConfigPath), expand.ListEnviron(os.Environ()...), c.Name, versionArgs...)
 		if err != nil {
 			aggregatedErrors = append(aggregatedErrors, fmt.Errorf("cannot run command '%s' (%v), however it is required by the config. Please make sure you have correctly installed '%s' with version %s", c.Name, err, c.Name, c.Version))
 			continue


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Some required commands output their version on stderr instead of stdout. Devspace is not handling stderr when running `command version` so it is not possible to assess that the command is installed with its right version. This change changes the behavior so stdout and stderr are combined and used the same to look for the version string/

**Please provide a short message that should be published in the DevSpace release notes**
Combine stdout and stderr for required commands when getting their version


**What else do we need to know?** 
This can potentially break compatibility since some programs can mix version data between stdout and stderr output. I assume this is an edge case that should not be common at all but is still possible.