### PR TITLE
fix: revert #2540 and add tests to prevent future regressions

### DIFF
--- a/pkg/devspace/config/config.go
+++ b/pkg/devspace/config/config.go
@@ -101,7 +101,7 @@ func Ensure(config Config) Config {
 		retConfig = NewConfig(map[string]interface{}{}, retConfig.RawBeforeConversion(), retConfig.Config(), retConfig.LocalCache(), retConfig.RemoteCache(), retConfig.Variables(), retConfig.Path())
 	}
 	if retConfig.RawBeforeConversion() == nil {
-		retConfig = NewConfig(retConfig.Raw(), map[string]interface{}{}, latest.NewRaw(), retConfig.LocalCache(), retConfig.RemoteCache(), retConfig.Variables(), retConfig.Path())
+		retConfig = NewConfig(retConfig.Raw(), map[string]interface{}{}, retConfig.Config(), retConfig.LocalCache(), retConfig.RemoteCache(), retConfig.Variables(), retConfig.Path())
 	}
 	if retConfig.Config() == nil {
 		retConfig = NewConfig(retConfig.Raw(), retConfig.RawBeforeConversion(), latest.NewRaw(), retConfig.LocalCache(), retConfig.RemoteCache(), retConfig.Variables(), retConfig.Path())

--- a/pkg/devspace/config/loader/variable/legacy/replace.go
+++ b/pkg/devspace/config/loader/variable/legacy/replace.go
@@ -175,7 +175,7 @@ func resolveImage(value string, config config2.Config, dependencies []types.Depe
 
 		// try to find the tag for the image
 		tag := originalTag
-		if tag == "" && imageCache.Tag != "" {
+		if imageCache.Tag != "" {
 			tag = imageCache.Tag
 		}
 

--- a/pkg/devspace/config/loader/variable/legacy/replace_test.go
+++ b/pkg/devspace/config/loader/variable/legacy/replace_test.go
@@ -83,6 +83,35 @@ func TestReplaceContainerNames(t *testing.T) {
 			},
 		},
 		{
+			name: "Image in cache replaces explicit tag",
+			overwriteValues: map[string]interface{}{
+				"": "myimage:master",
+			},
+			imagesConf: map[string]*latest.Image{
+				"test": {
+					Image: "myimage",
+				},
+			},
+			cache: &localcache.LocalCache{
+				Images: map[string]localcache.ImageCache{
+					"test": {
+						ImageName: "myimage",
+						Tag:       "someTag",
+					},
+				},
+			},
+			builtImages: map[string]buildtypes.ImageNameTag{
+				"test": {
+					ImageName: "myimage",
+					ImageTag:  "someTag",
+				},
+			},
+			expectedShouldRedeploy: true,
+			expectedOverwriteValues: map[string]interface{}{
+				"": "myimage:someTag",
+			},
+		},
+		{
 			name: "Replace image & tag helpers",
 			overwriteValues: map[string]interface{}{
 				"": "image(test):tag(test)",


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
A breaking change was made to the replace images logic. This adds tests to prevent future breaking changes.

May be related to #2573 and #2569, but needs further investigation.

**Please provide a short message that should be published in the DevSpace release notes**
Reverted a breaking change to image replace logic.
