### PR TITLE
feat: add config & path runtime variables for dependencies and imports

### DIFF
--- a/e2e/tests/dependencies/dependencies.go
+++ b/e2e/tests/dependencies/dependencies.go
@@ -291,6 +291,16 @@ dep2dep2wait
 		// calculate dependency path
 		dependencyPath := filepath.Join(dependencyutil.DependencyFolderPath, id)
 
+		// Should export dependency path
+		framework.ExpectLocalFileContents("runtime-path.txt", tempDir)
+		framework.ExpectLocalFileContents("runtime-config.txt", filepath.Join(tempDir, "devspace.yaml"))
+		framework.ExpectLocalFileContents("runtime-imports-0-path.txt", dependencyPath+"-imports")
+		framework.ExpectLocalFileContents("runtime-imports-0-config.txt", filepath.Join(dependencyPath+"-imports", "devspace.yaml"))
+		framework.ExpectLocalFileContents("dependency-path.txt", dependencyPath)
+		framework.ExpectLocalFileContents("dependency-config.txt", filepath.Join(dependencyPath, "devspace.yaml"))
+		framework.ExpectLocalFileContents("dependency-deploy-path.txt", dependencyPath)
+		framework.ExpectLocalFileContents("dependency-deploy-config.txt", filepath.Join(dependencyPath, "devspace.yaml"))
+
 		// wait until file is there
 		framework.ExpectLocalFileContents("imports.txt", "Test-dep-test\n")
 		framework.ExpectLocalFileContents(filepath.Join(dependencyPath, "dependency-dev.txt"), "Hello I am dependency\n")

--- a/e2e/tests/dependencies/testdata/git/devspace.yaml
+++ b/e2e/tests/dependencies/testdata/git/devspace.yaml
@@ -18,3 +18,11 @@ pipelines:
       run_dependencies dependency
       run_dependencies dependency-deploy > dependency.txt
       dep-test > imports.txt
+      echo -n $(get_runtime_variable 'runtime.config') > runtime-config.txt
+      echo -n $(get_runtime_variable 'runtime.path') > runtime-path.txt
+      echo -n $(get_runtime_variable 'runtime.imports[0].config') > runtime-imports-0-config.txt
+      echo -n $(get_runtime_variable 'runtime.imports[0].path') > runtime-imports-0-path.txt
+      echo -n $(get_runtime_variable 'runtime.dependencies.dependency.config') > dependency-config.txt
+      echo -n $(get_runtime_variable 'runtime.dependencies.dependency.path') > dependency-path.txt
+      echo -n $(get_runtime_variable 'runtime.dependencies.dependency-deploy.config') > dependency-deploy-config.txt
+      echo -n $(get_runtime_variable 'runtime.dependencies.dependency-deploy.path') > dependency-deploy-path.txt

--- a/pkg/devspace/config/config.go
+++ b/pkg/devspace/config/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/config/localcache"
 	"github.com/loft-sh/devspace/pkg/devspace/config/remotecache"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"path/filepath"
 )
 
 type Config interface {
@@ -34,9 +35,43 @@ type Config interface {
 	Path() string
 }
 
-func NewConfig(raw map[string]interface{}, rawBeforeConversion map[string]interface{}, parsed *latest.Config, localCache localcache.Cache, remoteCache remotecache.Cache, resolvedVariables map[string]interface{}, path string) Config {
+func NewConfig(
+	raw map[string]interface{},
+	rawBeforeConversion map[string]interface{},
+	parsed *latest.Config,
+	localCache localcache.Cache,
+	remoteCache remotecache.Cache,
+	resolvedVariables map[string]interface{},
+	path string,
+) Config {
+	runtimeVariables := NewRuntimeVariables()
+	return NewConfigWithRuntimeVariables(
+		raw,
+		rawBeforeConversion,
+		parsed,
+		localCache,
+		remoteCache,
+		resolvedVariables,
+		path,
+		runtimeVariables,
+	)
+}
+
+func NewConfigWithRuntimeVariables(
+	raw map[string]interface{},
+	rawBeforeConversion map[string]interface{},
+	parsed *latest.Config,
+	localCache localcache.Cache,
+	remoteCache remotecache.Cache,
+	resolvedVariables map[string]interface{},
+	path string,
+	runtimeVariables RuntimeVariables,
+) Config {
+	runtimeVariables.SetRuntimeVariable("config", path)
+	runtimeVariables.SetRuntimeVariable("path", filepath.Dir(path))
+
 	return &config{
-		RuntimeVariables:    newRuntimeVariables(),
+		RuntimeVariables:    runtimeVariables,
 		rawConfig:           raw,
 		rawBeforeConversion: rawBeforeConversion,
 		parsedConfig:        parsed,

--- a/pkg/devspace/config/loader/loader_test.go
+++ b/pkg/devspace/config/loader/loader_test.go
@@ -1940,8 +1940,10 @@ deployments:
 			&remotecache.RemoteCache{},
 			&fakekubectl.Client{},
 			NewDefaultParser(),
+			config2.NewRuntimeVariables(),
 			testCase.in.options,
-			log.Discard)
+			log.Discard,
+		)
 
 		if testCase.expectedErr != "" {
 			if err == nil {

--- a/pkg/devspace/config/runtime.go
+++ b/pkg/devspace/config/runtime.go
@@ -13,7 +13,7 @@ type RuntimeVariables interface {
 	SetRuntimeVariable(key string, value interface{})
 }
 
-func newRuntimeVariables() RuntimeVariables {
+func NewRuntimeVariables() RuntimeVariables {
 	return &runtimeVariables{
 		runtimeVariables: make(map[string]interface{}),
 	}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/commands/get_runtime_variable.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/commands/get_runtime_variable.go
@@ -1,0 +1,38 @@
+package commands
+
+import (
+	"fmt"
+	"github.com/jessevdk/go-flags"
+	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable/runtime"
+	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
+	"github.com/pkg/errors"
+	"mvdan.cc/sh/v3/interp"
+	"strings"
+)
+
+func GetRuntimeVariable(ctx devspacecontext.Context, args []string) error {
+	ctx = ctx.WithLogger(ctx.Log().ErrorStreamOnly())
+	ctx.Log().Debugf("get_image %s", strings.Join(args, " "))
+	options := &GetImageOptions{}
+	args, err := flags.ParseArgs(options, args)
+	if err != nil {
+		return errors.Wrap(err, "parse args")
+	}
+	if len(args) != 1 {
+		return fmt.Errorf("usage: get_runtime_variable [variable_name]")
+	}
+
+	_, runtimeVar, err := runtime.NewRuntimeVariable(args[0], ctx.Config(), ctx.Dependencies()).Load()
+	if err != nil {
+		return err
+	}
+
+	runtimeBytes, ok := runtimeVar.(string)
+	if !ok {
+		return fmt.Errorf("couldn't convert runtime variable %s to a string", args[0])
+	}
+
+	hc := interp.HandlerCtx(ctx.Context())
+	_, _ = hc.Stdout.Write([]byte(runtimeBytes))
+	return nil
+}

--- a/pkg/devspace/pipeline/engine/pipelinehandler/handler.go
+++ b/pkg/devspace/pipeline/engine/pipelinehandler/handler.go
@@ -31,6 +31,9 @@ var PipelineCommands = map[string]func(devCtx devspacecontext.Context, pipeline 
 	"get_image": func(devCtx devspacecontext.Context, pipeline types.Pipeline, args []string) error {
 		return commands.GetImage(devCtx, args)
 	},
+	"get_runtime_variable": func(devCtx devspacecontext.Context, pipeline types.Pipeline, args []string) error {
+		return commands.GetRuntimeVariable(devCtx, args)
+	},
 	"run_default_pipeline": func(devCtx devspacecontext.Context, pipeline types.Pipeline, args []string) error {
 		return commands.RunDefaultPipeline(devCtx, pipeline, args, NewPipelineExecHandler)
 	},


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind feature

**What does this pull request do? Which issues does it resolve?**
Adds runtime variables with the `devspace.yaml` config location and the path it's in:
`runtime.imports[i].config`
`runtime.imports[i].path`
`runtime.dependencies.[name].config`
`runtime.dependencies.[name].path`

resolves #2581
fixes ENG-1062

**Please provide a short message that should be published in the DevSpace release notes**
Added runtime variables to expose the location of dependencies and imports.


**What else do we need to know?**
Nested `dependencies` work, but nested `imports` do not. This is because imports are erased at load time and cannot be referred to later.

**TODO**
- [x] Add `runtime.config` and `runtime.path`
- [x] Test `runtime.config`, `runtime.path`, `runtime.dependencies.[name].config`, and `runtime.dependencies.[name].path`
- [x] Add `runtime.imports[i].config` and `runtime.imports[i].path`
- [ ] Add documation (pending initial review)
