### PR TITLE
fix: consider helm release name when showing helm deployment status

### DIFF
--- a/pkg/devspace/deploy/deployer/helm/status.go
+++ b/pkg/devspace/deploy/deployer/helm/status.go
@@ -3,6 +3,7 @@ package helm
 import (
 	"fmt"
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
+	"github.com/loft-sh/devspace/pkg/devspace/helm/types"
 
 	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer"
 	"github.com/loft-sh/devspace/pkg/devspace/helm"
@@ -44,7 +45,7 @@ func (d *DeployConfig) Status(ctx devspacecontext.Context) (*deployer.StatusResu
 	}
 
 	for _, release := range releases {
-		if release.Name == d.DeploymentConfig.Name {
+		if d.matchesRelease(release) {
 			if release.Status != "DEPLOYED" {
 				return &deployer.StatusResult{
 					Name:   d.DeploymentConfig.Name,
@@ -82,4 +83,13 @@ func (d *DeployConfig) getDeployTarget() string {
 	}
 
 	return retString
+}
+func (d *DeployConfig) matchesRelease(release *types.Release) bool {
+	if d.DeploymentConfig.Name == release.Name {
+		return true
+	}
+	if d.DeploymentConfig.Helm != nil && d.DeploymentConfig.Helm.ReleaseName == release.Name {
+		return true
+	}
+	return false
 }

--- a/pkg/devspace/deploy/deployer/helm/status_test.go
+++ b/pkg/devspace/deploy/deployer/helm/status_test.go
@@ -31,6 +31,51 @@ type statusTestCase struct {
 func TestStatus(t *testing.T) {
 	testCases := []statusTestCase{
 		{
+			name:       "Deployment successful",
+			deployment: "deployed",
+			releases: []*helmtypes.Release{
+				{
+					Name:   "deployed",
+					Status: "DEPLOYED",
+				},
+			},
+			helmConfig: &latest.HelmConfig{
+				Chart: &latest.ChartConfig{
+					Name:    "chartName",
+					Version: "chartVersion",
+				},
+			},
+			expectedStatus: deployer.StatusResult{
+				Name:   "deployed",
+				Type:   "Helm",
+				Target: "chartName (chartVersion)",
+				Status: "Deployed",
+			},
+		},
+		{
+			name:       "helmReleaseName",
+			deployment: "deployment",
+			releases: []*helmtypes.Release{
+				{
+					Name:   "releaseName",
+					Status: "DEPLOYED",
+				},
+			},
+			helmConfig: &latest.HelmConfig{
+				ReleaseName: "releaseName",
+				Chart: &latest.ChartConfig{
+					Name:    "chartName",
+					Version: "chartVersion",
+				},
+			},
+			expectedStatus: deployer.StatusResult{
+				Name:   "deployment",
+				Type:   "Helm",
+				Target: "chartName (chartVersion)",
+				Status: "Deployed",
+			},
+		},
+		{
 			name:       "No releases",
 			deployment: "depl",
 			expectedStatus: deployer.StatusResult{


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2626


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would not consider the configured helm release name when showing deployment statuses.


**What else do we need to know?** 
I wonder if some work should be done to avoid the potential of two deployments being configured as having the same helm release name or whether this would be considered a user error which wouldn't happen too often anyway.