### PR TITLE
fix: avoid reformatting yaml when there are no patches to apply

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 )
 
 require (
+	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
@@ -145,6 +146,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/syncthing/notify v0.0.0-20210616190510-c6b7342338d2 // indirect
 	github.com/tcnksm/go-gitconfig v0.1.2 // indirect
 	github.com/tonistiigi/fsutil v0.0.0-20230105215944-fb433841cbfa // indirect
@@ -157,6 +159,7 @@ require (
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.29.0 // indirect
 	go.opentelemetry.io/otel v1.4.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.4.1 // indirect
@@ -171,7 +174,7 @@ require (
 	golang.org/x/time v0.1.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220706185917-7780775163c4 // indirect
+	google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
 	gopkg.in/toqueteos/substring.v1 v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,7 +12,6 @@ cloud.google.com/go v0.54.0/go.mod h1:1rq2OEkV3YMf6n/9ZvGWI3GWw0VoqH/1x2nd8Is/bP
 cloud.google.com/go v0.56.0/go.mod h1:jr7tqZxxKOVYizybht9+26Z/gUq7tiRzu+ACVAMbKVk=
 cloud.google.com/go v0.57.0/go.mod h1:oXiQ6Rzq3RAkkY7N6t3TcE6jE+CIBBbA36lwQ1JyzZs=
 cloud.google.com/go v0.62.0/go.mod h1:jmCYTdRCQuc1PHIIJ/maLInMho30T/Y0M4hTdTShOYc=
-cloud.google.com/go v0.65.0 h1:Dg9iHVQfrhq82rUNu9ZxUDrJLaxFUe/HlCVaLyRruq8=
 cloud.google.com/go v0.65.0/go.mod h1:O5N8zS7uWy9vkA9vayVHs65eM1ubvY4h553ofrNHObY=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNFKH1/VBDHE=
@@ -20,7 +19,9 @@ cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvf
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
-cloud.google.com/go/compute v1.10.0 h1:aoLIYaA1fX3ywihqpBk2APQKOo20nXsp1GEZQbx5Jk4=
+cloud.google.com/go/compute v1.14.0 h1:hfm2+FfxVmnRlh6LpB7cg1ZNU+5edAHmW679JePztk0=
+cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
+cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
@@ -100,7 +101,6 @@ github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnht
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
 github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/compose-spec/compose-go v1.2.2 h1:y1dwl3KUTBnWPVur6EZno9zUIum6Q87/F5keljnGQB4=
 github.com/compose-spec/compose-go v1.2.2/go.mod h1:pAy7Mikpeft4pxkFU565/DRHEbDfR84G6AQuiL+Hdg8=
@@ -171,7 +171,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
-github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
 github.com/evanphx/json-patch v4.12.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -275,9 +274,9 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -563,6 +562,8 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -571,7 +572,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/syncthing/notify v0.0.0-20210616190510-c6b7342338d2 h1:F4snRP//nIuTTW9LYEzVH4HVwDG9T3M4t8y/2nqMbiY=
 github.com/syncthing/notify v0.0.0-20210616190510-c6b7342338d2/go.mod h1:J0q59IWjLtpRIJulohwqEZvjzwOfTEPp8SVhDJl+y0Y=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
@@ -616,7 +620,8 @@ go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
-go.opencensus.io v0.23.0 h1:gqCw0LfLxScz8irSi8exQc7fyQ0fKQU/qnC/X8+V/1M=
+go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
+go.opencensus.io v0.24.0/go.mod h1:vNK8G9p7aAivkbmorf4v+7Hgx+Zs0yY+0fOtgBfjQKo=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.29.0 h1:n9b7AAdbQtQ0k9dm0Dm2/KUcUqtG8i2O15KzNaDze8c=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.29.0/go.mod h1:LsankqVDx4W+RhZNA5uWarULII/MBhF5qwCYxTuyXjs=
 go.opentelemetry.io/otel v1.4.0/go.mod h1:jeAqMFKy2uLIxCtKxoFj0FAL5zAPKQagc3+GtBWakzk=
@@ -715,6 +720,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -790,7 +796,6 @@ golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -945,8 +950,8 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20220706185917-7780775163c4 h1:7YDGQC/0sigNGzsEWyb9s72jTxlFdwVEYNJHbfQ+Dtg=
-google.golang.org/genproto v0.0.0-20220706185917-7780775163c4/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
+google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd h1:OjndDrsik+Gt+e6fs45z9AxiewiKyLKYpA45W5Kpkks=
+google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd/go.mod h1:cTsE614GARnxrLsqKREzmNYJACSWWpAWdNMwnD7c2BE=
 google.golang.org/grpc v0.0.0-20160317175043-d3ddb4469d5a/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -961,10 +966,10 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
+google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
-google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.50.1 h1:DS/BukOZWp8s6p4Dt/tOaJaTQyPyOoCcrjroHuCeLzY=
 google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
@@ -980,7 +985,6 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
 google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/pkg/devspace/config/loader/patch/patch.go
+++ b/pkg/devspace/config/loader/patch/patch.go
@@ -14,20 +14,24 @@ type Patch []Operation
 
 // Apply returns a YAML document that has been mutated per patch
 func (p Patch) Apply(doc []byte) ([]byte, error) {
-	var node yaml.Node
-	err := yamlutil.Unmarshal(doc, &node)
+	if len(p) == 0 {
+		return doc, nil
+	}
+
+	node := &yaml.Node{}
+	err := yamlutil.Unmarshal(doc, node)
 	if err != nil {
 		return nil, fmt.Errorf("failed unmarshaling doc: %s\n\n%s", string(doc), err)
 	}
 
 	for _, op := range p {
-		err = op.Perform(&node)
+		err = op.Perform(node)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return yaml.Marshal(&node)
+	return yaml.Marshal(node)
 }
 
 func NewNode(raw *interface{}) (*yaml.Node, error) {

--- a/pkg/devspace/config/loader/patch/patch_test.go
+++ b/pkg/devspace/config/loader/patch/patch_test.go
@@ -1,0 +1,182 @@
+package patch
+
+import (
+	"testing"
+)
+
+type applyTestCase struct {
+	input  string
+	output string
+	patch  Patch
+}
+
+func TestApply(t *testing.T) {
+	testCases := map[string]applyTestCase{
+		// If it were processed, the indentation would be reset to 4 spaces
+		"noop no patches": {
+			input: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vela-core-application-test
+  namespace: vela-system
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -ec
+    - |2
+
+      set -e
+
+      echo "Application and its components are created"
+    image: oamdev/alpine-k8s:1.18.2
+    imagePullPolicy: IfNotPresent
+    name: vela-core-application-test
+  restartPolicy: Never
+  serviceAccountName: vela-core
+`,
+			output: `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vela-core-application-test
+  namespace: vela-system
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -ec
+    - |2
+
+      set -e
+
+      echo "Application and its components are created"
+    image: oamdev/alpine-k8s:1.18.2
+    imagePullPolicy: IfNotPresent
+    name: vela-core-application-test
+  restartPolicy: Never
+  serviceAccountName: vela-core
+`,
+		},
+		// TODO Failing test cases
+		//		"applies patch": {
+		//			input: `apiVersion: v1
+		//kind: Pod
+		//metadata:
+		//  annotations:
+		//    helm.sh/hook: test
+		//    helm.sh/hook-delete-policy: hook-succeeded
+		//  name: vela-core-application-test
+		//  namespace: vela-system
+		//spec:
+		//  containers:
+		//  - command:
+		//    - /bin/bash
+		//    - -ec
+		//    - |2
+		//
+		//      set -e
+		//
+		//      echo "Application and its components are created"
+		//    image: oamdev/alpine-k8s:1.18.2
+		//    imagePullPolicy: IfNotPresent
+		//    name: vela-core-application-test
+		//  restartPolicy: Never
+		//  serviceAccountName: vela-core
+		//`,
+		//			output: `apiVersion: v1
+		//kind: Pod
+		//metadata:
+		//  annotations:
+		//    helm.sh/hook: test
+		//    helm.sh/hook-delete-policy: hook-succeeded
+		//  name: vela-core-application-test
+		//  namespace: vela-system
+		//spec:
+		//  containers:
+		//    - command:
+		//        - /bin/bash
+		//        - -ec
+		//        - |2
+		//          set -e
+		//
+		//          echo "Application and its components are created"
+		//      image: oamdev/alpine-k8s:1.18.2
+		//      imagePullPolicy: IfNotPresent
+		//      name: vela-core-application-test
+		//  serviceAccountName: vela-core
+		//`,
+		//			patch: []Operation{
+		//				{
+		//					Op:   opRemove,
+		//					Path: "spec.restartPolicy",
+		//				},
+		//			},
+		//		},
+		//		"applies patch 4 spaces": {
+		//			input: `apiVersion: v1
+		//kind: Pod
+		//metadata:
+		//    annotations:
+		//        helm.sh/hook: test
+		//        helm.sh/hook-delete-policy: hook-succeeded
+		//    name: vela-core-application-test
+		//    namespace: vela-system
+		//spec:
+		//    containers:
+		//        - command:
+		//              - /bin/bash
+		//              - -ec
+		//              - |2
+		//
+		//                set -e
+		//
+		//                echo "Application and its components are created"
+		//          image: oamdev/alpine-k8s:1.18.2
+		//          imagePullPolicy: IfNotPresent
+		//          name: vela-core-application-test
+		//    restartPolicy: Never
+		//    serviceAccountName: vela-core
+		//`,
+		//			output: `apiVersion: v1
+		//kind: Pod
+		//metadata:
+		//    annotations:
+		//        helm.sh/hook: test
+		//        helm.sh/hook-delete-policy: hook-succeeded
+		//    name: vela-core-application-test
+		//    namespace: vela-system
+		//spec:
+		//    containers:
+		//        - command:
+		//              - /bin/bash
+		//              - -ec
+		//              - |2
+		//                set -e
+		//
+		//                echo "Application and its components are created"
+		//          image: oamdev/alpine-k8s:1.18.2
+		//          imagePullPolicy: IfNotPresent
+		//          name: vela-core-application-test
+		//    serviceAccountName: vela-core
+		//`,
+		//			patch: []Operation{
+		//				{
+		//					Op:   opRemove,
+		//					Path: "spec.restartPolicy",
+		//				},
+		//			},
+		//		},
+	}
+
+	for name, testCase := range testCases {
+		output, err := testCase.patch.Apply([]byte(testCase.input))
+		if err != nil {
+			t.Errorf("Error %v in case %s", err, name)
+		}
+		if testCase.output != string(output) {
+			t.Errorf("TestCase %s\nACTUAL:\n|%s|\nEXPECTED:\n|%s|", name, output, testCase.output)
+		}
+	}
+}

--- a/pkg/devspace/deploy/deployer/kubectl/builder.go
+++ b/pkg/devspace/deploy/deployer/kubectl/builder.go
@@ -3,23 +3,22 @@ package kubectl
 import (
 	"context"
 	"fmt"
-	"github.com/loft-sh/devspace/pkg/devspace/pipeline/env"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"mvdan.cc/sh/v3/expand"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 
-	"github.com/loft-sh/devspace/pkg/util/constraint"
-
-	"github.com/ghodss/yaml"
+	jsonyaml "github.com/ghodss/yaml"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"github.com/loft-sh/devspace/pkg/devspace/pipeline/env"
+	"github.com/loft-sh/devspace/pkg/util/constraint"
 	"github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/loft-sh/utils/pkg/command"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	"mvdan.cc/sh/v3/expand"
 )
 
 // Builder is the manifest builder interface
@@ -167,7 +166,7 @@ func stringToUnstructuredArray(out string) ([]*unstructured.Unstructured, error)
 	var firstErr error
 	for _, part := range parts {
 		var objMap map[string]interface{}
-		err := yaml.Unmarshal([]byte(part), &objMap)
+		err := jsonyaml.Unmarshal([]byte(part), &objMap)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("failed to unmarshal manifest: %v", err)
@@ -179,7 +178,7 @@ func stringToUnstructuredArray(out string) ([]*unstructured.Unstructured, error)
 			continue
 		}
 		var obj unstructured.Unstructured
-		err = yaml.Unmarshal([]byte(part), &obj)
+		err = jsonyaml.Unmarshal([]byte(part), &obj)
 		if err != nil {
 			if firstErr == nil {
 				firstErr = fmt.Errorf("failed to unmarshal manifest: %v", err)

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl.go
@@ -7,29 +7,25 @@ import (
 	"os"
 	"strings"
 
+	jsonyaml "github.com/ghodss/yaml"
 	"github.com/loft-sh/devspace/pkg/devspace/config/constants"
-	"mvdan.cc/sh/v3/expand"
-
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/patch"
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable/legacy"
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable/runtime"
 	"github.com/loft-sh/devspace/pkg/devspace/config/remotecache"
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
 	"github.com/loft-sh/devspace/pkg/devspace/context/values"
-	"github.com/loft-sh/devspace/pkg/util/stringutil"
-	"github.com/loft-sh/utils/pkg/command"
-	"github.com/sirupsen/logrus"
-
-	"github.com/loft-sh/utils/pkg/downloader"
-	"github.com/loft-sh/utils/pkg/downloader/commands"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-
-	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
-
-	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/deploy/deployer"
 	"github.com/loft-sh/devspace/pkg/util/hash"
+	"github.com/loft-sh/devspace/pkg/util/stringutil"
+	"github.com/loft-sh/utils/pkg/command"
+	"github.com/loft-sh/utils/pkg/downloader"
+	"github.com/loft-sh/utils/pkg/downloader/commands"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"mvdan.cc/sh/v3/expand"
 )
 
 var Cachemanifest = "./.devspace/manifest-cache.yaml"
@@ -162,7 +158,7 @@ func (d *DeployConfig) Deploy(ctx devspacecontext.Context, _ bool) (bool, error)
 	}
 
 	// Hash the deployment config
-	configStr, err := yaml.Marshal(d.DeploymentConfig)
+	configStr, err := jsonyaml.Marshal(d.DeploymentConfig)
 	if err != nil {
 		return false, errors.Wrap(err, "marshal deployment config")
 	}
@@ -291,7 +287,7 @@ func (d *DeployConfig) getReplacedManifest(ctx devspacecontext.Context, inline b
 			ctx.Log().Warn(err)
 		}
 
-		replacedManifest, err := yaml.Marshal(resource)
+		replacedManifest, err := jsonyaml.Marshal(resource)
 		if err != nil {
 			return false, "", nil, errors.Wrap(err, "marshal yaml")
 		}
@@ -347,7 +343,7 @@ func (d *DeployConfig) isKustomizeInstalled(ctx context.Context, dir, path strin
 }
 
 func (d *DeployConfig) applyDeployPatches(ctx devspacecontext.Context, resource *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-	out, err := yaml.Marshal(resource)
+	out, err := jsonyaml.Marshal(resource)
 	if err != nil {
 		return resource, err
 	}
@@ -395,7 +391,7 @@ func (d *DeployConfig) applyDeployPatches(ctx devspacecontext.Context, resource 
 
 	// transform resource back to unstructured
 	var result unstructured.Unstructured
-	err = yaml.Unmarshal(out, &result)
+	err = jsonyaml.Unmarshal(out, &result)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/google.golang.org/genproto/googleapis/api/httpbody/httpbody.pb.go
+++ b/vendor/google.golang.org/genproto/googleapis/api/httpbody/httpbody.pb.go
@@ -40,7 +40,6 @@ const (
 // payload formats that can't be represented as JSON, such as raw binary or
 // an HTML page.
 //
-//
 // This message can be used both in streaming and non-streaming API methods in
 // the request as well as the response.
 //
@@ -50,32 +49,32 @@ const (
 //
 // Example:
 //
-//     message GetResourceRequest {
-//       // A unique request id.
-//       string request_id = 1;
+//	message GetResourceRequest {
+//	  // A unique request id.
+//	  string request_id = 1;
 //
-//       // The raw HTTP body is bound to this field.
-//       google.api.HttpBody http_body = 2;
+//	  // The raw HTTP body is bound to this field.
+//	  google.api.HttpBody http_body = 2;
 //
-//     }
+//	}
 //
-//     service ResourceService {
-//       rpc GetResource(GetResourceRequest)
-//         returns (google.api.HttpBody);
-//       rpc UpdateResource(google.api.HttpBody)
-//         returns (google.protobuf.Empty);
+//	service ResourceService {
+//	  rpc GetResource(GetResourceRequest)
+//	    returns (google.api.HttpBody);
+//	  rpc UpdateResource(google.api.HttpBody)
+//	    returns (google.protobuf.Empty);
 //
-//     }
+//	}
 //
 // Example with streaming methods:
 //
-//     service CaldavService {
-//       rpc GetCalendar(stream google.api.HttpBody)
-//         returns (stream google.api.HttpBody);
-//       rpc UpdateCalendar(stream google.api.HttpBody)
-//         returns (stream google.api.HttpBody);
+//	service CaldavService {
+//	  rpc GetCalendar(stream google.api.HttpBody)
+//	    returns (stream google.api.HttpBody);
+//	  rpc UpdateCalendar(stream google.api.HttpBody)
+//	    returns (stream google.api.HttpBody);
 //
-//     }
+//	}
 //
 // Use of this type only changes how the request and response bodies are
 // handled, all other features will continue to work unchanged.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,3 +1,5 @@
+# cloud.google.com/go/compute/metadata v0.2.3
+## explicit; go 1.19
 # github.com/AlecAivazis/survey/v2 v2.3.2
 ## explicit; go 1.13
 github.com/AlecAivazis/survey/v2
@@ -569,6 +571,8 @@ github.com/src-d/gcfg
 github.com/src-d/gcfg/scanner
 github.com/src-d/gcfg/token
 github.com/src-d/gcfg/types
+# github.com/stretchr/testify v1.8.1
+## explicit; go 1.13
 # github.com/syncthing/notify v0.0.0-20210616190510-c6b7342338d2
 ## explicit; go 1.11
 # github.com/tcnksm/go-gitconfig v0.1.2
@@ -611,6 +615,8 @@ github.com/xeipuuv/gojsonreference
 # github.com/xeipuuv/gojsonschema v1.2.0
 ## explicit
 github.com/xeipuuv/gojsonschema
+# go.opencensus.io v0.24.0
+## explicit; go 1.13
 # go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.29.0
 ## explicit; go 1.16
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc
@@ -757,8 +763,8 @@ google.golang.org/appengine/internal/log
 google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
-# google.golang.org/genproto v0.0.0-20220706185917-7780775163c4
-## explicit; go 1.15
+# google.golang.org/genproto v0.0.0-20221202195650-67e5cbc046fd
+## explicit; go 1.19
 google.golang.org/genproto/googleapis/api/httpbody
 google.golang.org/genproto/googleapis/rpc/status
 google.golang.org/genproto/protobuf/field_mask


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Partial resolution of #2634


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would reformat yaml when 0 patches are applied


**What else do we need to know?** 
This is only a partial fix of #2634. If there are patches, the YAML formatting issue still occurs.

go.mod & go.sum changes were only to resolve issues running `go mod tidy` locally.

Other things tried:
- detecting and setting the encoder indentation: The same defect occurs if a YAML document with 4 spaces gets passed in, for example:
```yaml
test:
    example: |2
      Hello World!
```
would become invalid YAML when re-marshaled:
```yaml
test:
    example: |4
      Hello World!
```

Other suggestions:
- rewrite the yaml using the node tree.. but this will likely corrupt the original strings if they use the chomp indicator `|6+`
- probably best to wait for an official release.. or create a fork like kustomize has done. We may be able to use their fork once the PR is merged.

@89luca89  @FabianKramm 