### PR TITLE
Devspace command fails when cluster is not required

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -249,6 +249,13 @@ func (cmd *RunCmd) LoadCommandsConfig(f factory.Factory, configLoader loader.Con
 		client = nil
 	}
 
+	// verify client connectivity / authn / authz
+	_, err = client.KubeClient().Discovery().ServerVersion()
+	if err != nil {
+		log.Debugf("Unable to discover server version: %v", err)
+		client = nil
+	}
+
 	// Parse commands
 	commandsInterface, err := configLoader.LoadWithParser(context.Background(), localCache, client, loader.NewCommandsParser(), configOptions, log)
 	if err != nil {

--- a/e2e/tests/command/command.go
+++ b/e2e/tests/command/command.go
@@ -2,12 +2,13 @@ package command
 
 import (
 	"bytes"
-	"github.com/onsi/ginkgo/v2"
 	"os"
+	"path/filepath"
 
 	"github.com/loft-sh/devspace/cmd"
 	"github.com/loft-sh/devspace/cmd/flags"
 	"github.com/loft-sh/devspace/e2e/framework"
+	"github.com/onsi/ginkgo/v2"
 )
 
 var _ = DevSpaceDescribe("command", func() {
@@ -65,5 +66,25 @@ var _ = DevSpaceDescribe("command", func() {
 		err = runCmd.RunRun(f, []string{"test2", "test123", "test456"})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(stdout.String(), "test123 test456")
+	})
+
+	ginkgo.It("should run command without kubernetes cluster", func() {
+		tempDir, err := framework.CopyToTempDir("tests/command/testdata/command-without-cluster")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		defer os.Unsetenv("KUBECONFIG")
+		err = os.Setenv("KUBECONFIG", filepath.Join(tempDir, "config"))
+		framework.ExpectNoError(err)
+
+		stdout := &bytes.Buffer{}
+		runCmd := &cmd.RunCmd{
+			GlobalFlags: &flags.GlobalFlags{},
+			Stdout:      stdout,
+			Stderr:      stdout,
+		}
+		err = runCmd.RunRun(f, []string{"test"})
+		framework.ExpectNoError(err)
+		framework.ExpectEqual(stdout.String(), "Hello World")
 	})
 })

--- a/e2e/tests/command/testdata/command-without-cluster/config
+++ b/e2e/tests/command/testdata/command-without-cluster/config
@@ -1,0 +1,16 @@
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://127.0.0.1:52617
+  name: kind-kind
+contexts:
+- context:
+    cluster: kind-kind
+    user: kind-kind
+  name: kind-kind
+current-context: kind-kind
+kind: Config
+preferences: {}
+users:
+- name: kind-kind
+  user: {}

--- a/e2e/tests/command/testdata/command-without-cluster/devspace.yaml
+++ b/e2e/tests/command/testdata/command-without-cluster/devspace.yaml
@@ -1,0 +1,6 @@
+version: v2beta1
+name: command-without-cluster
+
+commands:
+  test: |-
+    echo -n "Hello World"


### PR DESCRIPTION
fixes #2648

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #2648


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace fails to load remote cache when running commands.
