### PR TITLE
Improve docs

### DIFF
--- a/cmd/flags/flags.go
+++ b/cmd/flags/flags.go
@@ -44,7 +44,7 @@ func SetGlobalFlags(flags *flag.FlagSet) *GlobalFlags {
 		Flags: flags,
 	}
 
-	flags.StringVar(&globalFlags.OverrideName, "override-name", "", "If specified will override the devspace.yaml name")
+	flags.StringVar(&globalFlags.OverrideName, "override-name", "", "If specified will override the DevSpace project name provided in the devspace.yaml")
 	flags.BoolVar(&globalFlags.NoWarn, "no-warn", false, "If true does not show any warning when deploying into a different namespace or kube-context than before")
 	flags.BoolVar(&globalFlags.NoColors, "no-colors", false, "Do not show color highlighting in log output. This avoids invisible output with different terminal background colors")
 	flags.BoolVar(&globalFlags.Debug, "debug", false, "Prints the stack trace if an error occurs")

--- a/docs/pages/cli.md
+++ b/docs/pages/cli.md
@@ -26,8 +26,9 @@ DevSpace accelerates developing, deploying and debugging applications with Docke
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_add.md
+++ b/docs/pages/cli/devspace_add.md
@@ -33,8 +33,9 @@ Adds config sections to devspace.yaml
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_add_plugin.md
+++ b/docs/pages/cli/devspace_add_plugin.md
@@ -41,8 +41,9 @@ devspace add plugin https://github.com/my-plugin/plugin
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_analyze.md
+++ b/docs/pages/cli/devspace_analyze.md
@@ -47,8 +47,9 @@ devspace analyze --namespace=mynamespace
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_attach.md
+++ b/docs/pages/cli/devspace_attach.md
@@ -48,8 +48,9 @@ devspace attach -n my-namespace
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_build.md
+++ b/docs/pages/cli/devspace_build.md
@@ -54,8 +54,9 @@ Builds all defined images and pushes them
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_cleanup.md
+++ b/docs/pages/cli/devspace_cleanup.md
@@ -32,8 +32,9 @@ Cleans up resources
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_cleanup_images.md
+++ b/docs/pages/cli/devspace_cleanup_images.md
@@ -38,8 +38,9 @@ Deletes all locally created docker images from docker
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_cleanup_local-registry.md
+++ b/docs/pages/cli/devspace_cleanup_local-registry.md
@@ -38,8 +38,9 @@ Deletes the local image registry
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_completion.md
+++ b/docs/pages/cli/devspace_completion.md
@@ -51,8 +51,9 @@ Outputs shell completion for the given shell (bash or zsh)
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_deploy.md
+++ b/docs/pages/cli/devspace_deploy.md
@@ -58,8 +58,9 @@ devspace deploy --kube-context=deploy-context
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_dev.md
+++ b/docs/pages/cli/devspace_dev.md
@@ -54,8 +54,9 @@ Starts your project in development mode
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_enter.md
+++ b/docs/pages/cli/devspace_enter.md
@@ -59,8 +59,9 @@ devspace enter bash --image-selector "${runtime.images.app.image}:${runtime.imag
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_init.md
+++ b/docs/pages/cli/devspace_init.md
@@ -43,8 +43,9 @@ folder. Creates a devspace.yaml as a starting point.
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list.md
+++ b/docs/pages/cli/devspace_list.md
@@ -32,8 +32,9 @@ Lists configuration
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list_commands.md
+++ b/docs/pages/cli/devspace_list_commands.md
@@ -39,8 +39,9 @@ devspace.yaml
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list_contexts.md
+++ b/docs/pages/cli/devspace_list_contexts.md
@@ -41,8 +41,9 @@ devspace list contexts
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list_deployments.md
+++ b/docs/pages/cli/devspace_list_deployments.md
@@ -38,8 +38,9 @@ Lists the status of all deployments
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list_namespaces.md
+++ b/docs/pages/cli/devspace_list_namespaces.md
@@ -38,8 +38,9 @@ Lists all namespaces in the selected kube context
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list_plugins.md
+++ b/docs/pages/cli/devspace_list_plugins.md
@@ -40,8 +40,9 @@ devspace list plugins
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list_ports.md
+++ b/docs/pages/cli/devspace_list_ports.md
@@ -39,8 +39,9 @@ Lists the port forwarding configurations
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list_profiles.md
+++ b/docs/pages/cli/devspace_list_profiles.md
@@ -38,8 +38,9 @@ Lists all DevSpace configurations for this project
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list_sync.md
+++ b/docs/pages/cli/devspace_list_sync.md
@@ -38,8 +38,9 @@ Lists the sync configuration
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_list_vars.md
+++ b/docs/pages/cli/devspace_list_vars.md
@@ -40,8 +40,9 @@ values
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_logs.md
+++ b/docs/pages/cli/devspace_logs.md
@@ -51,8 +51,9 @@ devspace logs --namespace=mynamespace
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_open.md
+++ b/docs/pages/cli/devspace_open.md
@@ -43,8 +43,9 @@ devspace open
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_print.md
+++ b/docs/pages/cli/devspace_print.md
@@ -41,8 +41,9 @@ profile after all patching and variable substitution
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_purge.md
+++ b/docs/pages/cli/devspace_purge.md
@@ -56,8 +56,9 @@ devspace purge
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_remove.md
+++ b/docs/pages/cli/devspace_remove.md
@@ -32,8 +32,9 @@ Removes devspace configuration
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_remove_context.md
+++ b/docs/pages/cli/devspace_remove_context.md
@@ -41,8 +41,9 @@ devspace remove context myspace
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_remove_plugin.md
+++ b/docs/pages/cli/devspace_remove_plugin.md
@@ -40,8 +40,9 @@ devspace remove plugin my-plugin
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_render.md
+++ b/docs/pages/cli/devspace_render.md
@@ -56,8 +56,9 @@ deployment.
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_reset.md
+++ b/docs/pages/cli/devspace_reset.md
@@ -32,8 +32,9 @@ Resets an cluster token
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_reset_dependencies.md
+++ b/docs/pages/cli/devspace_reset_dependencies.md
@@ -41,8 +41,9 @@ devspace reset dependencies
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_reset_pods.md
+++ b/docs/pages/cli/devspace_reset_pods.md
@@ -42,8 +42,9 @@ devspace reset pods
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_reset_vars.md
+++ b/docs/pages/cli/devspace_reset_vars.md
@@ -41,8 +41,9 @@ devspace reset vars
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_restart.md
+++ b/docs/pages/cli/devspace_restart.md
@@ -47,8 +47,9 @@ devspace restart -n my-namespace
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_run-pipeline.md
+++ b/docs/pages/cli/devspace_run-pipeline.md
@@ -56,8 +56,9 @@ devspace run-pipeline dev
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_run.md
+++ b/docs/pages/cli/devspace_run.md
@@ -44,8 +44,9 @@ devspace --dependency my-dependency run any-command --any-command-flag
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_set.md
+++ b/docs/pages/cli/devspace_set.md
@@ -32,8 +32,9 @@ Sets global configuration changes
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_set_var.md
+++ b/docs/pages/cli/devspace_set_var.md
@@ -43,8 +43,9 @@ devspace set var key=value key2=value2
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_sync.md
+++ b/docs/pages/cli/devspace_sync.md
@@ -58,8 +58,9 @@ devspace sync --path=.:/app --pod=my-pod --container=my-container
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_ui.md
+++ b/docs/pages/cli/devspace_ui.md
@@ -42,8 +42,9 @@ Opens the localhost UI in the browser
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_update.md
+++ b/docs/pages/cli/devspace_update.md
@@ -32,8 +32,9 @@ Updates the current config
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_update_plugin.md
+++ b/docs/pages/cli/devspace_update_plugin.md
@@ -41,8 +41,9 @@ devspace update plugin my-plugin
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_upgrade.md
+++ b/docs/pages/cli/devspace_upgrade.md
@@ -39,8 +39,9 @@ Upgrades the DevSpace CLI to the newest version
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_use.md
+++ b/docs/pages/cli/devspace_use.md
@@ -32,8 +32,9 @@ Uses specific config
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_use_context.md
+++ b/docs/pages/cli/devspace_use_context.md
@@ -41,8 +41,9 @@ devspace use context my-context
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_use_namespace.md
+++ b/docs/pages/cli/devspace_use_namespace.md
@@ -43,8 +43,9 @@ devspace use namespace my-namespace
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/cli/devspace_version.md
+++ b/docs/pages/cli/devspace_version.md
@@ -26,8 +26,9 @@ devspace version [flags]
       --kube-context string          The kubernetes context to use
       --kubeconfig string            The kubeconfig path to use
   -n, --namespace string             The kubernetes namespace to use
+      --no-colors                    Do not show color highlighting in log output. This avoids invisible output with different terminal background colors
       --no-warn                      If true does not show any warning when deploying into a different namespace or kube-context than before
-      --override-name string         If specified will override the devspace.yaml name
+      --override-name string         If specified will override the DevSpace project name provided in the devspace.yaml
   -p, --profile strings              The DevSpace profiles to apply. Multiple profiles are applied in the order they are specified
       --silent                       Run in silent mode and prevents any devspace log output except panics & fatals
   -s, --switch-context               Switches and uses the last kube context and namespace that was used to deploy the DevSpace project

--- a/docs/pages/configuration/_partials/v2beta1/name.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/name.mdx
@@ -2,11 +2,11 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-## `name` <span className="config-field-required" data-required="true">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#name}
+## `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#name}
 
 Name specifies the name of the DevSpace project and uniquely identifies a project.
 DevSpace will not allow multiple active projects with the same name in the same Kubernetes namespace.
-
+If not provided, DevSpace will use the name of the current working directory.
 </summary>
 
 


### PR DESCRIPTION
/kind documentation

Improves the docs by making some descriptions more specific
- Specify which name will be overridden with the `--override-name` flag
- Mark `name` property not required, but explain what happens when it's not provided
