### PR TITLE
docs: clarify where functions can be used

### DIFF
--- a/docs/pages/configuration/functions/README.mdx
+++ b/docs/pages/configuration/functions/README.mdx
@@ -43,6 +43,7 @@ pipelines:
     hello_world
     run_default_pipeline dev
 ```
+Please note that custom functions can only be called from `pipelines` and other `functions` as these run in a `pipeline` context.
 
 
 ## Built-In Functions


### PR DESCRIPTION
/kind documentation

Improves docs by clarifying that custom `functions` can only be called in the `pipelines` context
