### PR TITLE
fix: create /usr/local/bin for proxycommands if it doesn't exist in t…

### DIFF
--- a/e2e/tests/proxycommands/testdata/proxycommands-no-usr-local/devspace.yaml
+++ b/e2e/tests/proxycommands/testdata/proxycommands-no-usr-local/devspace.yaml
@@ -1,0 +1,30 @@
+version: v2beta1
+
+name: no-usr-local
+
+vars:
+  IMAGE: busybox
+
+deployments:
+  test:
+    helm:
+      chart:
+        name: component-chart
+        repo: https://charts.devspace.sh
+      values:
+        containers:
+          - image: ${IMAGE}
+            command: ["sleep"]
+            args: ["infinity"]
+
+dev:
+  test:
+    imageSelector: ${IMAGE}
+    proxyCommands:
+      - command: helm
+
+pipelines:
+  dev:
+    run: |
+      run_default_pipeline dev
+      exec_container --image-selector ${IMAGE} -- sh -c 'helm version > helm-version.out'


### PR DESCRIPTION
…he base container


**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2676
Fixes ENG-1731


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would error when proxying commands to a container without a /usr/local/bin directory.
