### PR TITLE
clarify only supported build engines for localRegistry

### DIFF
--- a/docs/pages/configuration/localRegistry/README.mdx
+++ b/docs/pages/configuration/localRegistry/README.mdx
@@ -13,6 +13,10 @@ Unless persistence is enabled, the local registry will be deployed using a `Depl
 
 Local registry configuration is defined in the `localRegistry` section of the `devspace.yaml`.
 
+:::note
+localRegistry currently only supports docker and buildkit
+:::
+
 <Tabs
     defaultValue="default"
     values={[


### PR DESCRIPTION
/kind documentation

Explicitly state which build engines are supported for using `localRegistry`