### PR TITLE
fix: --dependency flag is respected by dependency resolving

### DIFF
--- a/cmd/run_pipeline.go
+++ b/cmd/run_pipeline.go
@@ -340,7 +340,7 @@ func initialize(ctx context.Context, f factory.Factory, options *CommandOptions,
 	}
 
 	// resolve dependencies
-	dependencies, err := f.NewDependencyManager(devCtx, options.ConfigOptions).ResolveAll(devCtx, dependency.ResolveOptions{SkipDependencies: options.DependencyOptions.Exclude})
+	dependencies, err := f.NewDependencyManager(devCtx, options.ConfigOptions).ResolveAll(devCtx, dependency.ResolveOptions{SkipDependencies: options.DependencyOptions.Exclude, Dependencies: options.DependencyOptions.Only})
 	if err != nil {
 		return nil, errors.Wrap(err, "deploy dependencies")
 	}

--- a/pkg/devspace/dependency/manager.go
+++ b/pkg/devspace/dependency/manager.go
@@ -40,7 +40,7 @@ func NewManagerWithParser(ctx devspacecontext.Context, configOptions *loader.Con
 
 type ResolveOptions struct {
 	SkipDependencies []string
-	Dependencies     []string // Same as DependencyOptions.Only, either should be renamed
+	Dependencies     []string
 }
 
 func (m *manager) ResolveAll(ctx devspacecontext.Context, options ResolveOptions) ([]types.Dependency, error) {

--- a/pkg/devspace/dependency/manager.go
+++ b/pkg/devspace/dependency/manager.go
@@ -2,6 +2,8 @@ package dependency
 
 import (
 	"bytes"
+	"strings"
+
 	"github.com/loft-sh/devspace/pkg/devspace/build"
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader"
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
@@ -11,7 +13,6 @@ import (
 	"github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"strings"
 )
 
 // Manager can update, build, deploy and purge dependencies.
@@ -39,7 +40,7 @@ func NewManagerWithParser(ctx devspacecontext.Context, configOptions *loader.Con
 
 type ResolveOptions struct {
 	SkipDependencies []string
-	Dependencies     []string
+	Dependencies     []string // Same as DependencyOptions.Only, either should be renamed
 }
 
 func (m *manager) ResolveAll(ctx devspacecontext.Context, options ResolveOptions) ([]types.Dependency, error) {

--- a/pkg/devspace/dependency/resolver.go
+++ b/pkg/devspace/dependency/resolver.go
@@ -18,6 +18,7 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/types"
 	"github.com/loft-sh/devspace/pkg/devspace/dependency/util"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/util/stringutil"
 	"github.com/pkg/errors"
 )
 
@@ -117,6 +118,10 @@ func (r *resolver) resolveRecursive(ctx devspacecontext.Context, basePath, paren
 	}
 	for _, dependencyConfig := range dependencies {
 		if contains(options.SkipDependencies, dependencyConfig.Name) {
+			continue
+		}
+
+		if len(options.Dependencies) > 0 && !stringutil.Contains(options.Dependencies, dependencyConfig.Name) {
 			continue
 		}
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Partly solves #2641


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace flag --dependency was not respected by the git repo recursive resolver


**What else do we need to know?** 

I have not ran any unit tests or e2e tests as your contribution guide and bash scripts dont work on windows.

I have tested manually by building a devspace.exe file and then tested these 3 cases standing in a repo with a complex dependency hierarchy:

1 - Normal `C:\Projects\devspace-deps-fix\devspace.exe deploy --debug`
-> Download all repos and deploy all

2 - Filter away all `C:\Projects\devspace-deps-fix\devspace.exe deploy --dependency "-" --debug`
-> Download no repos, and deploy only self

3 - Filter to one dependency `C:\Projects\devspace-deps-fix\devspace.exe deploy --dependency "hn-oppsett" --debug`
-> Download dependency, and deploy it and self