### PR TITLE
fix: correctly use local git repo dependencies cache

### DIFF
--- a/pkg/devspace/dependency/util/util.go
+++ b/pkg/devspace/dependency/util/util.go
@@ -99,7 +99,7 @@ func DownloadDependency(ctx context.Context, workingDirectory string, source *la
 		_, statErr := os.Stat(localPath)
 
 		// Update dependency
-		if !source.DisablePull || statErr != nil {
+		if !source.DisablePull && statErr != nil {
 			repo, err := git.NewGitCLIRepository(ctx, localPath)
 			if err != nil {
 				if statErr == nil {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2641


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace deploy did not correctly use the `C:\Users\[user]\.devspace\dependencies` cached files, ending up always pulling the git repo.


**What else do we need to know?** 
- Not able to write tests for this as the test scripts dont work on windows.
- Tested locally by building devspace.exe and calling `C:\Projects\devspace-deps-fix\devspace.exe deploy --debug`