### PR TITLE
Clarify cleanup command

### DIFF
--- a/docs/pages/cli/devspace_cleanup_images.md
+++ b/docs/pages/cli/devspace_cleanup_images.md
@@ -4,7 +4,7 @@ sidebar_label: devspace cleanup images
 ---
 
 
-Deletes all locally created images from docker
+Deletes all locally created images from docker, which are defined in the `devspace.yaml`'s `images` section
 
 ## Synopsis
 


### PR DESCRIPTION
When executing `devspace cleanup images` only the images that have been defined in the `devspace.yaml` are being deleted. This was not explicit in the docs