### PR TITLE
docs: add hooks config reference and document default container timeout

### DIFF
--- a/devspace-schema.json
+++ b/devspace-schema.json
@@ -361,7 +361,8 @@
         },
         "updateImageTags": {
           "type": "boolean",
-          "description": "UpdateImageTags lets you define if DevSpace should update the tags of the images defined in the\nimages section with their most recent built tag."
+          "description": "UpdateImageTags lets you define if DevSpace should update the tags of the images defined in the\nimages section with their most recent built tag.",
+          "default": true
         },
         "namespace": {
           "type": "string",
@@ -752,6 +753,159 @@
       },
       "type": "object",
       "description": "HelmConfig defines the specific helm options used during deployment"
+    },
+    "HookConfig": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name is the name of the hook"
+        },
+        "disabled": {
+          "type": "boolean",
+          "description": "Disabled can be used to disable the hook"
+        },
+        "events": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Events are the events when the hook should be executed"
+        },
+        "command": {
+          "type": "string",
+          "description": "Command is the base command that is either executed locally or in a remote container.\nCommand is mutually exclusive with other hook actions. In the case this is defined\ntogether with where.container, DevSpace will until the target container is running and\nonly then execute the command. If the container does not start in time, DevSpace will fail."
+        },
+        "args": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "description": "Args are additional arguments passed together with the command to execute."
+        },
+        "os": {
+          "type": "string",
+          "description": "If an operating system is defined, the hook will only be executed for the given os.\nAll supported golang OS types are supported and multiple can be combined with ','."
+        },
+        "upload": {
+          "$ref": "#/$defs/HookSyncConfig",
+          "description": "If Upload is specified, DevSpace will upload certain local files or folders into a\nremote container."
+        },
+        "download": {
+          "$ref": "#/$defs/HookSyncConfig",
+          "description": "Same as Upload, but with this option DevSpace will download files or folders from\na remote container."
+        },
+        "logs": {
+          "$ref": "#/$defs/HookLogsConfig",
+          "description": "If logs is defined will print the logs of the target container. This is useful for containers\nthat should finish like init containers or job pods. Otherwise this hook will never terminate."
+        },
+        "wait": {
+          "$ref": "#/$defs/HookWaitConfig",
+          "description": "If wait is defined the hook will wait until the matched pod or container is running or is terminated\nwith a certain exit code."
+        },
+        "background": {
+          "type": "boolean",
+          "description": "If true, the hook will be executed in the background."
+        },
+        "silent": {
+          "type": "boolean",
+          "description": "If true, the hook will not output anything to the standard out of DevSpace except\nfor the case when the hook fails, where DevSpace will show the error including\nthe captured output streams of the hook."
+        },
+        "container": {
+          "$ref": "#/$defs/HookContainer",
+          "description": "Container specifies where the hook should be run. If this is omitted DevSpace expects a\nlocal command hook."
+        }
+      },
+      "type": "object",
+      "required": [
+        "events"
+      ],
+      "description": "HookConfig defines a hook"
+    },
+    "HookContainer": {
+      "properties": {
+        "labelSelector": {
+          "patternProperties": {
+            ".*": {
+              "type": "string"
+            }
+          },
+          "type": "object",
+          "description": "LabelSelector to select a container"
+        },
+        "pod": {
+          "type": "string",
+          "description": "Pod name to use"
+        },
+        "namespace": {
+          "type": "string",
+          "description": "Namespace to use"
+        },
+        "imageSelector": {
+          "type": "string",
+          "description": "ImageSelector to select a container"
+        },
+        "containerName": {
+          "type": "string",
+          "description": "ContainerName to use"
+        },
+        "wait": {
+          "type": "boolean",
+          "description": "Wait can be used to disable waiting"
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "Timeout is how long to wait (in seconds) for the container to start. Default is 150 seconds.",
+          "default": 150
+        },
+        "once": {
+          "type": "boolean",
+          "description": "Once only executes an hook once in the container until it is restarted"
+        }
+      },
+      "type": "object",
+      "description": "HookContainer defines how to select one or more containers to execute a hook in"
+    },
+    "HookLogsConfig": {
+      "properties": {
+        "tailLines": {
+          "type": "integer",
+          "description": "If set, the number of lines from the end of the logs to show. If not specified,\nlogs are shown from the creation of the container"
+        }
+      },
+      "type": "object",
+      "description": "HookLogsConfig defines a hook logs config"
+    },
+    "HookSyncConfig": {
+      "properties": {
+        "localPath": {
+          "type": "string",
+          "description": "LocalPath to sync files from"
+        },
+        "containerPath": {
+          "type": "string",
+          "description": "ContainerPath to sync files to"
+        }
+      },
+      "type": "object",
+      "description": "HookSyncConfig defines a hook upload config"
+    },
+    "HookWaitConfig": {
+      "properties": {
+        "running": {
+          "type": "boolean",
+          "description": "If running is true, will wait until the matched containers are running. Can be used together with terminatedWithCode."
+        },
+        "terminatedWithCode": {
+          "type": "integer",
+          "description": "If terminatedWithCode is not nil, will wait until the matched containers are terminated with the given exit code.\nIf the container has exited with a different exit code, the hook will fail. Can be used together with running."
+        },
+        "timeout": {
+          "type": "integer",
+          "description": "The amount of seconds to wait until the hook will fail. Defaults to 150 seconds."
+        }
+      },
+      "type": "object",
+      "description": "HookWaitConfig defines a hook wait config"
     },
     "Image": {
       "properties": {
@@ -2209,6 +2363,13 @@
     "require": {
       "$ref": "#/$defs/RequireConfig",
       "description": "Require defines what DevSpace, plugins and command versions are required to use this config and if a condition is not\nfulfilled, DevSpace will fail."
+    },
+    "hooks": {
+      "items": {
+        "$ref": "#/$defs/HookConfig"
+      },
+      "type": "array",
+      "description": "Hooks are actions that are executed at certain points within the pipeline. Hooks are ordered and are executed\nin the order they are specified. They are deprecated and pipelines should be used instead."
     },
     "localRegistry": {
       "$ref": "#/$defs/LocalRegistryConfig",

--- a/docs/hack/util/schema.go
+++ b/docs/hack/util/schema.go
@@ -182,10 +182,22 @@ func createSections(basePath, prefix string, schema *jsonschema.Schema, definiti
 					fieldPartial = fmt.Sprintf(TemplateConfigField, true, "", headlinePrefix, fieldName, false, fieldType, "", "", anchorName, fieldSchema.Description, fieldPartial)
 				} else {
 					if fieldType == "boolean" {
-						fieldDefault = "false"
 						if required {
 							fieldDefault = "true"
 							required = false
+						} else {
+							fieldDefault = "false"
+							boolDefault, ok := fieldSchema.Default.(bool)
+							if ok && boolDefault {
+								fieldDefault = "true"
+							}
+						}
+					} else if fieldType == "integer" {
+						intDefault, ok := fieldSchema.Default.(int)
+						if ok {
+							fieldDefault = strconv.Itoa(intDefault)
+						} else {
+							fieldDefault = ""
 						}
 					} else {
 						fieldDefault, ok = fieldSchema.Default.(string)

--- a/docs/pages/configuration/_partials/v2beta1/deployments/updateImageTags.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/deployments/updateImageTags.mdx
@@ -2,7 +2,7 @@
 <details className="config-field" data-expandable="false" open>
 <summary>
 
-### `updateImageTags` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#deployments-updateImageTags}
+### `updateImageTags` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">true</span> <span className="config-field-enum"></span> {#deployments-updateImageTags}
 
 UpdateImageTags lets you define if DevSpace should update the tags of the images defined in the
 images section with their most recent built tag.

--- a/docs/pages/configuration/_partials/v2beta1/hooks.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks.mdx
@@ -1,0 +1,18 @@
+
+import PartialHooksreference from "./hooks_reference.mdx"
+
+
+<details className="config-field" data-expandable="true" open>
+<summary>
+
+## `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks}
+
+Hooks are actions that are executed at certain points within the pipeline. Hooks are ordered and are executed
+in the order they are specified. They are deprecated and pipelines should be used instead.
+
+</summary>
+
+<PartialHooksreference />
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/args.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/args.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `args` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-args}
+
+Args are additional arguments passed together with the command to execute.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/background.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/background.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `background` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#hooks-background}
+
+If true, the hook will be executed in the background.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/command.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/command.mdx
@@ -1,0 +1,16 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `command` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-command}
+
+Command is the base command that is either executed locally or in a remote container.
+Command is mutually exclusive with other hook actions. In the case this is defined
+together with where.container, DevSpace will until the target container is running and
+only then execute the command. If the container does not start in time, DevSpace will fail.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container.mdx
@@ -1,0 +1,18 @@
+
+import PartialContainerreference from "./container_reference.mdx"
+
+
+<details className="config-field" data-expandable="true" open>
+<summary>
+
+### `container` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-container}
+
+Container specifies where the hook should be run. If this is omitted DevSpace expects a
+local command hook.
+
+</summary>
+
+<PartialContainerreference />
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container/containerName.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container/containerName.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `containerName` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-container-containerName}
+
+ContainerName to use
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container/imageSelector.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container/imageSelector.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `imageSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-container-imageSelector}
+
+ImageSelector to select a container
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container/labelSelector.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container/labelSelector.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `labelSelector` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">&lt;labelSelector_name&gt;:string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-container-labelSelector}
+
+LabelSelector to select a container
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container/namespace.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container/namespace.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `namespace` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-container-namespace}
+
+Namespace to use
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container/once.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container/once.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `once` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#hooks-container-once}
+
+Once only executes an hook once in the container until it is restarted
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container/pod.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container/pod.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `pod` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-container-pod}
+
+Pod name to use
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container/timeout.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container/timeout.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default">150</span> <span className="config-field-enum"></span> {#hooks-container-timeout}
+
+Timeout is how long to wait (in seconds) for the container to start. Default is 150 seconds.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container/wait.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container/wait.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#hooks-container-wait}
+
+Wait can be used to disable waiting
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/container_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/container_reference.mdx
@@ -1,0 +1,32 @@
+
+import PartialLabelSelector from "./container/labelSelector.mdx"
+import PartialPod from "./container/pod.mdx"
+import PartialNamespace from "./container/namespace.mdx"
+import PartialImageSelector from "./container/imageSelector.mdx"
+import PartialContainerName from "./container/containerName.mdx"
+import PartialWait from "./container/wait.mdx"
+import PartialTimeout from "./container/timeout.mdx"
+import PartialOnce from "./container/once.mdx"
+
+<PartialLabelSelector />
+
+
+<PartialPod />
+
+
+<PartialNamespace />
+
+
+<PartialImageSelector />
+
+
+<PartialContainerName />
+
+
+<PartialWait />
+
+
+<PartialTimeout />
+
+
+<PartialOnce />

--- a/docs/pages/configuration/_partials/v2beta1/hooks/disabled.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/disabled.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `disabled` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#hooks-disabled}
+
+Disabled can be used to disable the hook
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/download.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/download.mdx
@@ -1,0 +1,18 @@
+
+import PartialDownloadreference from "./download_reference.mdx"
+
+
+<details className="config-field" data-expandable="true" open>
+<summary>
+
+### `download` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-download}
+
+Same as Upload, but with this option DevSpace will download files or folders from
+a remote container.
+
+</summary>
+
+<PartialDownloadreference />
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/download/containerPath.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/download/containerPath.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `containerPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-download-containerPath}
+
+ContainerPath to sync files to
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/download/localPath.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/download/localPath.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `localPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-download-localPath}
+
+LocalPath to sync files from
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/download_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/download_reference.mdx
@@ -1,0 +1,8 @@
+
+import PartialLocalPath from "./download/localPath.mdx"
+import PartialContainerPath from "./download/containerPath.mdx"
+
+<PartialLocalPath />
+
+
+<PartialContainerPath />

--- a/docs/pages/configuration/_partials/v2beta1/hooks/events.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/events.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `events` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-events}
+
+Events are the events when the hook should be executed
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/logs.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/logs.mdx
@@ -1,0 +1,18 @@
+
+import PartialLogsreference from "./logs_reference.mdx"
+
+
+<details className="config-field" data-expandable="true" open>
+<summary>
+
+### `logs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-logs}
+
+If logs is defined will print the logs of the target container. This is useful for containers
+that should finish like init containers or job pods. Otherwise this hook will never terminate.
+
+</summary>
+
+<PartialLogsreference />
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/logs/tailLines.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/logs/tailLines.mdx
@@ -1,0 +1,14 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `tailLines` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-logs-tailLines}
+
+If set, the number of lines from the end of the logs to show. If not specified,
+logs are shown from the creation of the container
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/logs_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/logs_reference.mdx
@@ -1,0 +1,4 @@
+
+import PartialTailLines from "./logs/tailLines.mdx"
+
+<PartialTailLines />

--- a/docs/pages/configuration/_partials/v2beta1/hooks/name.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/name.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `name` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-name}
+
+Name is the name of the hook
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/os.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/os.mdx
@@ -1,0 +1,14 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `os` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-os}
+
+If an operating system is defined, the hook will only be executed for the given os.
+All supported golang OS types are supported and multiple can be combined with ','.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/silent.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/silent.mdx
@@ -1,0 +1,15 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+### `silent` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#hooks-silent}
+
+If true, the hook will not output anything to the standard out of DevSpace except
+for the case when the hook fails, where DevSpace will show the error including
+the captured output streams of the hook.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/upload.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/upload.mdx
@@ -1,0 +1,18 @@
+
+import PartialUploadreference from "./upload_reference.mdx"
+
+
+<details className="config-field" data-expandable="true" open>
+<summary>
+
+### `upload` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-upload}
+
+If Upload is specified, DevSpace will upload certain local files or folders into a
+remote container.
+
+</summary>
+
+<PartialUploadreference />
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/upload/containerPath.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/upload/containerPath.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `containerPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-upload-containerPath}
+
+ContainerPath to sync files to
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/upload/localPath.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/upload/localPath.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `localPath` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-upload-localPath}
+
+LocalPath to sync files from
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/upload_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/upload_reference.mdx
@@ -1,0 +1,8 @@
+
+import PartialLocalPath from "./upload/localPath.mdx"
+import PartialContainerPath from "./upload/containerPath.mdx"
+
+<PartialLocalPath />
+
+
+<PartialContainerPath />

--- a/docs/pages/configuration/_partials/v2beta1/hooks/wait.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/wait.mdx
@@ -1,0 +1,18 @@
+
+import PartialWaitreference from "./wait_reference.mdx"
+
+
+<details className="config-field" data-expandable="true" open>
+<summary>
+
+### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-wait}
+
+If wait is defined the hook will wait until the matched pod or container is running or is terminated
+with a certain exit code.
+
+</summary>
+
+<PartialWaitreference />
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/wait/running.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/wait/running.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `running` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">boolean</span> <span className="config-field-default">false</span> <span className="config-field-enum"></span> {#hooks-wait-running}
+
+If running is true, will wait until the matched containers are running. Can be used together with terminatedWithCode.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/wait/terminatedWithCode.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/wait/terminatedWithCode.mdx
@@ -1,0 +1,14 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `terminatedWithCode` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-wait-terminatedWithCode}
+
+If terminatedWithCode is not nil, will wait until the matched containers are terminated with the given exit code.
+If the container has exited with a different exit code, the hook will fail. Can be used together with running.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/wait/timeout.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/wait/timeout.mdx
@@ -1,0 +1,13 @@
+
+<details className="config-field" data-expandable="false" open>
+<summary>
+
+#### `timeout` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">integer</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-wait-timeout}
+
+The amount of seconds to wait until the hook will fail. Defaults to 150 seconds.
+
+</summary>
+
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/hooks/wait_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks/wait_reference.mdx
@@ -1,0 +1,12 @@
+
+import PartialRunning from "./wait/running.mdx"
+import PartialTerminatedWithCode from "./wait/terminatedWithCode.mdx"
+import PartialTimeout from "./wait/timeout.mdx"
+
+<PartialRunning />
+
+
+<PartialTerminatedWithCode />
+
+
+<PartialTimeout />

--- a/docs/pages/configuration/_partials/v2beta1/hooks_reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/hooks_reference.mdx
@@ -1,0 +1,122 @@
+
+import PartialName from "./hooks/name.mdx"
+import PartialDisabled from "./hooks/disabled.mdx"
+import PartialEvents from "./hooks/events.mdx"
+import PartialCommand from "./hooks/command.mdx"
+import PartialArgs from "./hooks/args.mdx"
+import PartialOs from "./hooks/os.mdx"
+import PartialUploadreference from "./hooks/upload_reference.mdx"
+import PartialDownloadreference from "./hooks/download_reference.mdx"
+import PartialLogsreference from "./hooks/logs_reference.mdx"
+import PartialWaitreference from "./hooks/wait_reference.mdx"
+import PartialBackground from "./hooks/background.mdx"
+import PartialSilent from "./hooks/silent.mdx"
+import PartialContainerreference from "./hooks/container_reference.mdx"
+
+<PartialName />
+
+
+<PartialDisabled />
+
+
+<PartialEvents />
+
+
+<PartialCommand />
+
+
+<PartialArgs />
+
+
+<PartialOs />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `upload` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-upload}
+
+If Upload is specified, DevSpace will upload certain local files or folders into a
+remote container.
+
+</summary>
+
+<PartialUploadreference />
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `download` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-download}
+
+Same as Upload, but with this option DevSpace will download files or folders from
+a remote container.
+
+</summary>
+
+<PartialDownloadreference />
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `logs` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-logs}
+
+If logs is defined will print the logs of the target container. This is useful for containers
+that should finish like init containers or job pods. Otherwise this hook will never terminate.
+
+</summary>
+
+<PartialLogsreference />
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `wait` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-wait}
+
+If wait is defined the hook will wait until the matched pod or container is running or is terminated
+with a certain exit code.
+
+</summary>
+
+<PartialWaitreference />
+
+
+</details>
+
+
+<PartialBackground />
+
+
+<PartialSilent />
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+### `container` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type"></span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks-container}
+
+Container specifies where the hook should be run. If this is omitted DevSpace expects a
+local command hook.
+
+</summary>
+
+<PartialContainerreference />
+
+
+</details>

--- a/docs/pages/configuration/_partials/v2beta1/reference.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/reference.mdx
@@ -12,6 +12,7 @@ import PartialCommandsreference from "./commands_reference.mdx"
 import PartialDependenciesreference from "./dependencies_reference.mdx"
 import PartialPullSecretsreference from "./pullSecrets_reference.mdx"
 import PartialRequirereference from "./require_reference.mdx"
+import PartialHooksreference from "./hooks_reference.mdx"
 import PartialLocalRegistryreference from "./localRegistry_reference.mdx"
 
 <PartialVersion />
@@ -308,6 +309,23 @@ fulfilled, DevSpace will fail.
 </summary>
 
 <PartialRequirereference />
+
+
+</details>
+
+
+
+<details className="config-field" data-expandable="true">
+<summary>
+
+## `hooks` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">object[]</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#hooks}
+
+Hooks are actions that are executed at certain points within the pipeline. Hooks are ordered and are executed
+in the order they are specified. They are deprecated and pipelines should be used instead.
+
+</summary>
+
+<PartialHooksreference />
 
 
 </details>

--- a/docs/pages/configuration/deployments/README.mdx
+++ b/docs/pages/configuration/deployments/README.mdx
@@ -95,6 +95,6 @@ Given the example above, you can now run:
   2. Then deploy `api` and `payments` in parallel
 
 
-## Configuration
+## Config Reference
 
 <ConfigPartialDeployments/>

--- a/docs/pages/configuration/hooks/README.mdx
+++ b/docs/pages/configuration/hooks/README.mdx
@@ -3,6 +3,8 @@ title: Hooks
 sidebar_label: hooks
 ---
 
+import ConfigPartialHooks from '../_partials/v2beta1/hooks.mdx'
+
 DevSpace allows you to define certain actions that should be executed during the pipeline. This makes it possible to customize the deployment and development process with DevSpace. The following actions can be executed with hooks:
 - Execute a command on the local machine (in a golang shell or directly on the system)
 - Execute a command in a container
@@ -274,3 +276,7 @@ DevSpace passes certain environment variables to the hook execution:
 - **DEVSPACE_HOOK_EVENT**: the event that has triggered the hook
 
 Depending on the hook there will be other context variables set that are prefixed with `DEVSPACE_HOOK_`. 
+
+## Config Reference
+
+<ConfigPartialHooks />

--- a/docs/schemas/config-openapi.json
+++ b/docs/schemas/config-openapi.json
@@ -369,7 +369,8 @@
               },
               "updateImageTags": {
                 "type": "boolean",
-                "description": "UpdateImageTags lets you define if DevSpace should update the tags of the images defined in the\nimages section with their most recent built tag."
+                "description": "UpdateImageTags lets you define if DevSpace should update the tags of the images defined in the\nimages section with their most recent built tag.",
+                "default": true
               },
               "namespace": {
                 "type": "string",
@@ -760,6 +761,159 @@
             },
             "type": "object",
             "description": "HelmConfig defines the specific helm options used during deployment"
+          },
+          "HookConfig": {
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Name is the name of the hook"
+              },
+              "disabled": {
+                "type": "boolean",
+                "description": "Disabled can be used to disable the hook"
+              },
+              "events": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "Events are the events when the hook should be executed"
+              },
+              "command": {
+                "type": "string",
+                "description": "Command is the base command that is either executed locally or in a remote container.\nCommand is mutually exclusive with other hook actions. In the case this is defined\ntogether with where.container, DevSpace will until the target container is running and\nonly then execute the command. If the container does not start in time, DevSpace will fail."
+              },
+              "args": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array",
+                "description": "Args are additional arguments passed together with the command to execute."
+              },
+              "os": {
+                "type": "string",
+                "description": "If an operating system is defined, the hook will only be executed for the given os.\nAll supported golang OS types are supported and multiple can be combined with ','."
+              },
+              "upload": {
+                "$ref": "#/definitions/Config/$defs/HookSyncConfig",
+                "description": "If Upload is specified, DevSpace will upload certain local files or folders into a\nremote container."
+              },
+              "download": {
+                "$ref": "#/definitions/Config/$defs/HookSyncConfig",
+                "description": "Same as Upload, but with this option DevSpace will download files or folders from\na remote container."
+              },
+              "logs": {
+                "$ref": "#/definitions/Config/$defs/HookLogsConfig",
+                "description": "If logs is defined will print the logs of the target container. This is useful for containers\nthat should finish like init containers or job pods. Otherwise this hook will never terminate."
+              },
+              "wait": {
+                "$ref": "#/definitions/Config/$defs/HookWaitConfig",
+                "description": "If wait is defined the hook will wait until the matched pod or container is running or is terminated\nwith a certain exit code."
+              },
+              "background": {
+                "type": "boolean",
+                "description": "If true, the hook will be executed in the background."
+              },
+              "silent": {
+                "type": "boolean",
+                "description": "If true, the hook will not output anything to the standard out of DevSpace except\nfor the case when the hook fails, where DevSpace will show the error including\nthe captured output streams of the hook."
+              },
+              "container": {
+                "$ref": "#/definitions/Config/$defs/HookContainer",
+                "description": "Container specifies where the hook should be run. If this is omitted DevSpace expects a\nlocal command hook."
+              }
+            },
+            "type": "object",
+            "required": [
+              "events"
+            ],
+            "description": "HookConfig defines a hook"
+          },
+          "HookContainer": {
+            "properties": {
+              "labelSelector": {
+                "patternProperties": {
+                  ".*": {
+                    "type": "string"
+                  }
+                },
+                "type": "object",
+                "description": "LabelSelector to select a container"
+              },
+              "pod": {
+                "type": "string",
+                "description": "Pod name to use"
+              },
+              "namespace": {
+                "type": "string",
+                "description": "Namespace to use"
+              },
+              "imageSelector": {
+                "type": "string",
+                "description": "ImageSelector to select a container"
+              },
+              "containerName": {
+                "type": "string",
+                "description": "ContainerName to use"
+              },
+              "wait": {
+                "type": "boolean",
+                "description": "Wait can be used to disable waiting"
+              },
+              "timeout": {
+                "type": "integer",
+                "description": "Timeout is how long to wait (in seconds) for the container to start. Default is 150 seconds.",
+                "default": 150
+              },
+              "once": {
+                "type": "boolean",
+                "description": "Once only executes an hook once in the container until it is restarted"
+              }
+            },
+            "type": "object",
+            "description": "HookContainer defines how to select one or more containers to execute a hook in"
+          },
+          "HookLogsConfig": {
+            "properties": {
+              "tailLines": {
+                "type": "integer",
+                "description": "If set, the number of lines from the end of the logs to show. If not specified,\nlogs are shown from the creation of the container"
+              }
+            },
+            "type": "object",
+            "description": "HookLogsConfig defines a hook logs config"
+          },
+          "HookSyncConfig": {
+            "properties": {
+              "localPath": {
+                "type": "string",
+                "description": "LocalPath to sync files from"
+              },
+              "containerPath": {
+                "type": "string",
+                "description": "ContainerPath to sync files to"
+              }
+            },
+            "type": "object",
+            "description": "HookSyncConfig defines a hook upload config"
+          },
+          "HookWaitConfig": {
+            "properties": {
+              "running": {
+                "type": "boolean",
+                "description": "If running is true, will wait until the matched containers are running. Can be used together with terminatedWithCode."
+              },
+              "terminatedWithCode": {
+                "type": "integer",
+                "description": "If terminatedWithCode is not nil, will wait until the matched containers are terminated with the given exit code.\nIf the container has exited with a different exit code, the hook will fail. Can be used together with running."
+              },
+              "timeout": {
+                "type": "integer",
+                "description": "The amount of seconds to wait until the hook will fail. Defaults to 150 seconds."
+              }
+            },
+            "type": "object",
+            "description": "HookWaitConfig defines a hook wait config"
           },
           "Image": {
             "properties": {
@@ -2202,6 +2356,13 @@
           "require": {
             "$ref": "#/definitions/Config/$defs/RequireConfig",
             "description": "Require defines what DevSpace, plugins and command versions are required to use this config and if a condition is not\nfulfilled, DevSpace will fail."
+          },
+          "hooks": {
+            "items": {
+              "$ref": "#/definitions/Config/$defs/HookConfig"
+            },
+            "type": "array",
+            "description": "Hooks are actions that are executed at certain points within the pipeline. Hooks are ordered and are executed\nin the order they are specified. They are deprecated and pipelines should be used instead."
           },
           "localRegistry": {
             "$ref": "#/definitions/Config/$defs/LocalRegistryConfig",

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/google/go-containerregistry v0.13.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/websocket v1.4.2
-	github.com/invopop/jsonschema v0.3.0
+	github.com/invopop/jsonschema v0.4.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/joho/godotenv v1.3.0
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -395,8 +395,8 @@ github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf/go.mod h
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/invopop/jsonschema v0.3.0 h1:bLc7vCIFtaJYARy0JXnc/IKZygCms+lfOK4BaJM+fkI=
-github.com/invopop/jsonschema v0.3.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
+github.com/invopop/jsonschema v0.4.0 h1:Yuy/unfgCnfV5Wl7H0HgFufp/rlurqPOOuacqyByrws=
+github.com/invopop/jsonschema v0.4.0/go.mod h1:O9uiLokuu0+MGFlyiaqtWxwqJm41/+8Nj0lD7A36YH0=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -118,7 +118,7 @@ type Config struct {
 
 	// Hooks are actions that are executed at certain points within the pipeline. Hooks are ordered and are executed
 	// in the order they are specified. They are deprecated and pipelines should be used instead.
-	Hooks []*HookConfig `yaml:"hooks,omitempty" json:"hooks,omitempty" jsonschema:"-"`
+	Hooks []*HookConfig `yaml:"hooks,omitempty" json:"hooks,omitempty"`
 
 	// LocalRegistry specifies the configuration for a local image registry
 	LocalRegistry *LocalRegistryConfig `yaml:"localRegistry,omitempty" json:"localRegistry,omitempty"`
@@ -648,7 +648,7 @@ type DeploymentConfig struct {
 
 	// UpdateImageTags lets you define if DevSpace should update the tags of the images defined in the
 	// images section with their most recent built tag.
-	UpdateImageTags *bool `yaml:"updateImageTags,omitempty" json:"updateImageTags,omitempty"`
+	UpdateImageTags *bool `yaml:"updateImageTags,omitempty" json:"updateImageTags,omitempty" jsonschema:"default=true"`
 
 	// Namespace where to deploy this deployment
 	Namespace string `yaml:"namespace,omitempty" json:"namespace,omitempty"`
@@ -1470,8 +1470,8 @@ type HookContainer struct {
 	// Wait can be used to disable waiting
 	Wait *bool `yaml:"wait,omitempty" json:"wait,omitempty"`
 
-	// Timeout how long to wait
-	Timeout int64 `yaml:"timeout,omitempty" json:"timeout,omitempty"`
+	// Timeout is how long to wait (in seconds) for the container to start. Default is 150 seconds.
+	Timeout int64 `yaml:"timeout,omitempty" json:"timeout,omitempty" jsonschema:"default=150"`
 
 	// Once only executes an hook once in the container until it is restarted
 	Once *bool `yaml:"once,omitempty" json:"once,omitempty"`

--- a/vendor/github.com/invopop/jsonschema/README.md
+++ b/vendor/github.com/invopop/jsonschema/README.md
@@ -350,7 +350,7 @@ As you can see, if a field name has a `json:""` or `yaml:""` tag set, the `key` 
 
 Sometimes it can be useful to have custom JSON Marshal and Unmarshal methods in your structs that automatically convert for example a string into an object.
 
-To override auto-generating an object type for your type, implement the `JSONSchema() *Type` method and whatever is defined will be provided in the schema definitions.
+To override auto-generating an object type for your type, implement the `JSONSchema() *Schema` method and whatever is defined will be provided in the schema definitions.
 
 Take the following simplified example of a `CompactDate` that only includes the Year and Month:
 
@@ -384,8 +384,8 @@ func (d *CompactDate) MarshalJSON() ([]byte, error) {
   return buf.Bytes(), nil
 }
 
-func (CompactDate) JSONSchema() *Type {
-	return &Type{
+func (CompactDate) JSONSchema() *Schema {
+	return &Schema{
 		Type:        "string",
 		Title:       "Compact Date",
 		Description: "Short date that only includes year and month",

--- a/vendor/github.com/invopop/jsonschema/reflect.go
+++ b/vendor/github.com/invopop/jsonschema/reflect.go
@@ -618,6 +618,8 @@ func (t *Schema) structKeywordsFromTags(f reflect.StructField, parent *Schema, p
 		t.numbericKeywords(tags)
 	case "array":
 		t.arrayKeywords(tags)
+	case "boolean":
+		t.booleanKeywords(tags)
 	}
 	extras := strings.Split(f.Tag.Get("jsonschema_extras"), ",")
 	t.extraKeywords(extras)
@@ -680,6 +682,24 @@ func (t *Schema) genericKeywords(tags []string, parent *Schema, propertyName str
 	}
 }
 
+// read struct tags for boolean type keyworks
+func (t *Schema) booleanKeywords(tags []string) {
+	for _, tag := range tags {
+		nameValue := strings.Split(tag, "=")
+		if len(nameValue) != 2 {
+			continue
+		}
+		name, val := nameValue[0], nameValue[1]
+		if name == "default" {
+			if val == "true" {
+				t.Default = true
+			} else if val == "false" {
+				t.Default = false
+			}
+		}
+	}
+}
+
 // read struct tags for string type keyworks
 func (t *Schema) stringKeywords(tags []string) {
 	for _, tag := range tags {
@@ -697,7 +717,7 @@ func (t *Schema) stringKeywords(tags []string) {
 				t.Pattern = val
 			case "format":
 				switch val {
-				case "date-time", "email", "hostname", "ipv4", "ipv6", "uri":
+				case "date-time", "email", "hostname", "ipv4", "ipv6", "uri", "uuid":
 					t.Format = val
 					break
 				}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -336,7 +336,7 @@ github.com/inconshreveable/go-update/internal/osext
 # github.com/inconshreveable/mousetrap v1.0.1
 ## explicit; go 1.18
 github.com/inconshreveable/mousetrap
-# github.com/invopop/jsonschema v0.3.0
+# github.com/invopop/jsonschema v0.4.0
 ## explicit; go 1.16
 github.com/invopop/jsonschema
 # github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?**
Resolves #2701
Replaces #2582
Fixes ENG-1958


**Please provide a short message that should be published in the DevSpace release notes**
- Upgraded invopop/jsonschema to allow handling of boolean defaults 
- Updated documented defaults for `updateImageTags`, since it was incorrectly documented as `false`
- Added `hooks` config reference and documented the default `150` timeout for `hooks.*.container.timeout`.


**What else do we need to know?** 
Fixes handling of default values for integers and booleans when generating documentation.