### PR TITLE
fix: prevent panic when checking server version without a kube contex…

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -250,10 +250,12 @@ func (cmd *RunCmd) LoadCommandsConfig(f factory.Factory, configLoader loader.Con
 	}
 
 	// verify client connectivity / authn / authz
-	_, err = client.KubeClient().Discovery().ServerVersion()
-	if err != nil {
-		log.Debugf("Unable to discover server version: %v", err)
-		client = nil
+	if client != nil {
+		_, err = client.KubeClient().Discovery().ServerVersion()
+		if err != nil {
+			log.Debugf("Unable to discover server version: %v", err)
+			client = nil
+		}
 	}
 
 	// Parse commands


### PR DESCRIPTION
…t configured


**What issue type does this pull request address?**
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
Resolves #2711
Fixed ENG-2019


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace panics when the kube context is unset


**What else do we need to know?** 
Typically does not happen if `kubectl config current-context` returns successfully. Running `minikube delete` can clear the current-context.