### PR TITLE
fix: remote cache key should consider helm release name

### DIFF
--- a/pkg/devspace/deploy/deployer/helm/deploy.go
+++ b/pkg/devspace/deploy/deployer/helm/deploy.go
@@ -69,7 +69,7 @@ func (d *DeployConfig) Deploy(ctx devspacecontext.Context, forceDeploy bool) (bo
 	}
 
 	// Ensure deployment config is there
-	deployCache, _ := ctx.Config().RemoteCache().GetDeployment(d.DeploymentConfig.Name)
+	deployCache, _ := ctx.Config().RemoteCache().GetDeployment(releaseName)
 
 	// Check values files for changes
 	helmOverridesHash := ""
@@ -158,14 +158,14 @@ func (d *DeployConfig) Deploy(ctx devspacecontext.Context, forceDeploy bool) (bo
 		if rootName, ok := values.RootNameFrom(ctx.Context()); ok && !stringutil.Contains(deployCache.Projects, rootName) {
 			deployCache.Projects = append(deployCache.Projects, rootName)
 		}
-		ctx.Config().RemoteCache().SetDeployment(d.DeploymentConfig.Name, deployCache)
+		ctx.Config().RemoteCache().SetDeployment(releaseName, deployCache)
 		return true, nil
 	}
 
 	if rootName, ok := values.RootNameFrom(ctx.Context()); ok && !stringutil.Contains(deployCache.Projects, rootName) {
 		deployCache.Projects = append(deployCache.Projects, rootName)
 	}
-	ctx.Config().RemoteCache().SetDeployment(d.DeploymentConfig.Name, deployCache)
+	ctx.Config().RemoteCache().SetDeployment(releaseName, deployCache)
 	return false, nil
 }
 
@@ -191,7 +191,7 @@ func (d *DeployConfig) internalDeploy(ctx devspacecontext.Context, overwriteValu
 		return nil, nil
 	}
 
-	ctx.Log().Infof("Deploying chart %s (%s) with helm...", d.DeploymentConfig.Helm.Chart.Name, d.DeploymentConfig.Name)
+	ctx.Log().Infof("Deploying chart %s (%s) with helm...", d.DeploymentConfig.Helm.Chart.Name, releaseName)
 	valuesOut, _ := yaml.Marshal(overwriteValues)
 	ctx.Log().Debugf("Deploying chart with values:\n %v\n", string(valuesOut))
 

--- a/pkg/devspace/deploy/deployer/helm/deploy_test.go
+++ b/pkg/devspace/deploy/deployer/helm/deploy_test.go
@@ -27,6 +27,7 @@ type deployTestCase struct {
 	// builtImages    map[string]string
 	releasesBefore []*helmtypes.Release
 	deployment     string
+	releaseName    string
 	chart          string
 	valuesFiles    []string
 	values         map[string]interface{}
@@ -82,6 +83,30 @@ func TestDeploy(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:       "Deploy one deployment with different release name",
+			deployment: "deploy2",
+			chart:      ".",
+			values: map[string]interface{}{
+				"val": "fromVal",
+			},
+			releaseName:      "deploy2-special",
+			expectedDeployed: true,
+			expectedCache: &remotecache.RemoteCache{
+				Deployments: []remotecache.DeploymentCache{
+					{
+						Name:                 "deploy2-special",
+						DeploymentConfigHash: "aca018bdc51747a41d18361a2a678bb64fd36f834d62303b538dcdbb50c5b410",
+						Helm: &remotecache.HelmCache{
+							Release:          "deploy2-special",
+							ReleaseNamespace: "testNamespace",
+							ReleaseRevision:  "1",
+							ValuesHash:       "efd6e101b768968a49f8dba46ef07785ac530ea9f75c4f9ca5733e223b6a4da1",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -106,6 +131,7 @@ func TestDeploy(t *testing.T) {
 					Chart: &latest.ChartConfig{
 						Name: testCase.chart,
 					},
+					ReleaseName: testCase.releaseName,
 					ValuesFiles: testCase.valuesFiles,
 					Values:      testCase.values,
 				},


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**

resolves #2525 

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would leave behind orphaned helm releases when setting a helm release name


**What else do we need to know?** 
It doesn't fully fix the use case in #2525, as the originally expected behavior doesn't play well with `devspace` currently.
However, this fix makes `devspace` avoid "orphaned" deployments lingering around.
IMO this is the behavior most people would expect, as the default is to purge all deployments associated with a project.