### PR TITLE
change: when stopping upstream/downstream, also close grpc connections

### DIFF
--- a/helper/server/downstream.go
+++ b/helper/server/downstream.go
@@ -4,9 +4,6 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"context"
-	"github.com/loft-sh/devspace/helper/util/pingtimeout"
-	"github.com/loft-sh/devspace/pkg/util/fsutil"
-	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 	"io"
 	"log"
 	"os"
@@ -14,6 +11,10 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/loft-sh/devspace/helper/util/pingtimeout"
+	"github.com/loft-sh/devspace/pkg/util/fsutil"
+	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 
 	"github.com/loft-sh/devspace/helper/server/ignoreparser"
 	"github.com/loft-sh/devspace/helper/util/stderrlog"

--- a/pkg/devspace/sync/downstream.go
+++ b/pkg/devspace/sync/downstream.go
@@ -14,6 +14,7 @@ import (
 	"github.com/loft-sh/devspace/helper/server/ignoreparser"
 	"github.com/loft-sh/devspace/helper/util"
 	"github.com/loft-sh/devspace/pkg/util/fsutil"
+	"google.golang.org/grpc"
 
 	"github.com/fujiwara/shapeio"
 	"github.com/pkg/errors"
@@ -27,6 +28,7 @@ type downstream struct {
 	client remote.DownstreamClient
 
 	ignoreMatcher ignoreparser.IgnoreParser
+	conn          *grpc.ClientConn
 
 	unarchiver *Unarchiver
 }
@@ -71,6 +73,7 @@ func newDownstream(reader io.ReadCloser, writer io.WriteCloser, sync *Sync) (*do
 		client:        remote.NewDownstreamClient(conn),
 		ignoreMatcher: ignoreMatcher,
 		unarchiver:    NewUnarchiver(sync, false, sync.log),
+		conn:          conn,
 	}, nil
 }
 

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -415,6 +415,9 @@ func (s *Sync) Stop(fatalError error) {
 			if s.upstream.reader != nil {
 				s.upstream.reader.Close()
 			}
+			if s.upstream.conn != nil {
+				s.upstream.conn.Close()
+			}
 		}
 
 		if s.downstream != nil {
@@ -423,6 +426,9 @@ func (s *Sync) Stop(fatalError error) {
 			}
 			if s.downstream.reader != nil {
 				s.downstream.reader.Close()
+			}
+			if s.downstream.conn != nil {
+				s.downstream.conn.Close()
 			}
 		}
 

--- a/pkg/devspace/sync/upstream.go
+++ b/pkg/devspace/sync/upstream.go
@@ -22,9 +22,10 @@ import (
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/pipeline/engine"
 	"github.com/loft-sh/devspace/pkg/util/fsutil"
+	"google.golang.org/grpc"
 
-	"github.com/loft-sh/utils/pkg/command"
 	"github.com/loft-sh/notify"
+	"github.com/loft-sh/utils/pkg/command"
 
 	"github.com/bmatcuk/doublestar"
 	"github.com/fujiwara/shapeio"
@@ -57,6 +58,8 @@ type upstream struct {
 	initialSyncChanges        []string
 	initialSyncCompleted      bool
 	initialSyncTouchOnce      sync.Once
+
+	conn *grpc.ClientConn
 }
 
 const (
@@ -111,6 +114,8 @@ func newUpstream(reader io.ReadCloser, writer io.WriteCloser, sync *Sync) (*upst
 		client: remote.NewUpstreamClient(conn),
 
 		ignoreMatcher: ignoreMatcher,
+
+		conn: conn,
 	}, nil
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2738 

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace left over orphaned GRPC connections when pods are removed.


**What else do we need to know?** 

This reduces the annoying grpc logs to 2 coming from the ping, just before the connection gets closed.