### PR TITLE
pass namespace to kubectl build to fix incluster bug

### DIFF
--- a/pkg/devspace/deploy/deployer/kubectl/builder.go
+++ b/pkg/devspace/deploy/deployer/kubectl/builder.go
@@ -25,7 +25,7 @@ import (
 
 // Builder is the manifest builder interface
 type Builder interface {
-	Build(ctx context.Context, environ expand.Environ, dir, manifest string) ([]*unstructured.Unstructured, error)
+	Build(ctx context.Context, environ expand.Environ, dir, namespace string, manifest string) ([]*unstructured.Unstructured, error)
 }
 
 type kustomizeBuilder struct {
@@ -42,7 +42,7 @@ func NewKustomizeBuilder(path string, config *latest.DeploymentConfig, log log.L
 	}
 }
 
-func (k *kustomizeBuilder) Build(ctx context.Context, environ expand.Environ, dir, manifest string) ([]*unstructured.Unstructured, error) {
+func (k *kustomizeBuilder) Build(ctx context.Context, environ expand.Environ, dir, namespace string, manifest string) ([]*unstructured.Unstructured, error) {
 	args := []string{"build", manifest}
 	args = append(args, k.config.Kubectl.KustomizeArgs...)
 
@@ -108,7 +108,7 @@ var useOldDryRun = func(ctx context.Context, environ expand.Environ, dir, path s
 	return false, nil
 }
 
-func (k *kubectlBuilder) Build(ctx context.Context, environ expand.Environ, dir, manifest string) ([]*unstructured.Unstructured, error) {
+func (k *kubectlBuilder) Build(ctx context.Context, environ expand.Environ, dir, namespace string, manifest string) ([]*unstructured.Unstructured, error) {
 	tempFile, err := os.CreateTemp("", "")
 	if err != nil {
 		return nil, err
@@ -135,9 +135,9 @@ func (k *kubectlBuilder) Build(ctx context.Context, environ expand.Environ, dir,
 	}
 
 	if uodr {
-		args = append(args, "--dry-run", "--output", "yaml", "--validate=false")
+		args = append(args, "--dry-run", "--output", "yaml", "--validate=false", "-n", namespace)
 	} else {
-		args = append(args, "--dry-run=client", "--output", "yaml", "--validate=false")
+		args = append(args, "--dry-run=client", "--output", "yaml", "--validate=false", "-n", namespace)
 	}
 
 	if k.config.Kubectl.Kustomize != nil && *k.config.Kubectl.Kustomize {

--- a/pkg/devspace/deploy/deployer/kubectl/kubectl.go
+++ b/pkg/devspace/deploy/deployer/kubectl/kubectl.go
@@ -321,7 +321,7 @@ func (d *DeployConfig) buildManifests(ctx devspacecontext.Context, manifest stri
 	}
 
 	if d.DeploymentConfig.Kubectl.Kustomize != nil && *d.DeploymentConfig.Kubectl.Kustomize && d.isKustomizeInstalled(ctx.Context(), ctx.WorkingDir(), kustomizePath) {
-		return NewKustomizeBuilder(kustomizePath, d.DeploymentConfig, ctx.Log()).Build(ctx.Context(), ctx.Environ(), ctx.WorkingDir(), manifest)
+		return NewKustomizeBuilder(kustomizePath, d.DeploymentConfig, ctx.Log()).Build(ctx.Context(), ctx.Environ(), ctx.WorkingDir(), ctx.KubeClient().Namespace(), manifest)
 	}
 
 	raw, err := ctx.KubeClient().KubeConfigLoader().LoadRawConfig()
@@ -334,7 +334,7 @@ func (d *DeployConfig) buildManifests(ctx devspacecontext.Context, manifest stri
 	}
 
 	// Build with kubectl
-	return NewKubectlBuilder(d.CmdPath, d.DeploymentConfig, *copied).Build(ctx.Context(), ctx.Environ(), ctx.WorkingDir(), manifest)
+	return NewKubectlBuilder(d.CmdPath, d.DeploymentConfig, *copied).Build(ctx.Context(), ctx.Environ(), ctx.WorkingDir(), ctx.KubeClient().Namespace(), manifest)
 }
 
 func (d *DeployConfig) isKustomizeInstalled(ctx context.Context, dir, path string) bool {


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2745


**Please provide a short message that should be published in the DevSpace release notes**
Fixes an issue where DevSpace, when ran `incluster`, would deploy kubectl manifest files in the wrong namespace even when `-n` is provided on the command line.

**What else do we need to know?** 

I'm not setup to run the e2e for this yet but I did test the fix with kubectl (not yet with kustomize). 
Since it's such a simple fix I figured I might as well open the PR to get some opinions while I do more testing.
