### PR TITLE
docs: update incorrect createPullSecrets reference

### DIFF
--- a/docs/pages/configuration/images/pull.mdx
+++ b/docs/pages/configuration/images/pull.mdx
@@ -13,7 +13,7 @@ In many cases, DevSpace automatically creates pull secrets for you but you can a
 DevSpace can automatically create pull secrets to provide registry credentials for Kubernetes to pull images from these private registries. DevSpace retrieves the credentials from your local credentials store in Docker.
 
 The following functions can be called in the scripts defined in your `pipelines` section and when DevSpace executes them, it triggers pull secrets to be created:
-1. `build_images` (unless `createPullSecrets` is `false` for the respective image in the `images` section of `devspace.yaml`)
+1. `build_images` (unless [`createPullSecret`](../images#images-createPullSecret) is `false` for the respective image)
 2. `ensure_pull_secrets`
 
 ### Manual


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2730
resovles ENG-2186

**Please provide a short message that should be published in the DevSpace release notes**
Fixed incorrect reference to `createPullSecret` in documentation.