### PR TITLE
docs: move is_dependency to correct function group

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -47,3 +47,10 @@ cd ../ # main project directory
 
 go run ./docs/hack/config/schemas/main.go
 ```
+
+### Generate Function Docs
+```bash
+cd ../ # main project directory
+
+go run ./docs/hack/functions/main.go
+```

--- a/docs/hack/functions/main.go
+++ b/docs/hack/functions/main.go
@@ -336,6 +336,15 @@ var Functions = []Function{
 		IsGlobal:    true,
 	},
 	{
+		Name:        "is_in",
+		Description: "Returns exit code 0 if the value of the first argument can be found in the second argument (second argument being a blank-separated list of strings e.g `\"bananas apples peaches\"`)",
+		Args:        `[value-1] [value-2]`,
+		Handler:     basiccommands.IsIn,
+		Return:      reflect.Int.String(),
+		Group:       groupChecks,
+		IsGlobal:    true,
+	},
+	{
 		Name:        "is_os",
 		Description: `Returns exit code 0 if the current operating system equals the value provided as argument`,
 		Args:        `[os]`,

--- a/docs/hack/functions/main.go
+++ b/docs/hack/functions/main.go
@@ -315,7 +315,6 @@ var Functions = []Function{
 		Handler:     commands.IsDependency,
 		Return:      reflect.Int.String(),
 		Group:       groupChecks,
-		IsGlobal:    true,
 	},
 	{
 		Name:        "is_empty",

--- a/docs/pages/configuration/_partials/functions/group_checks.mdx
+++ b/docs/pages/configuration/_partials/functions/group_checks.mdx
@@ -4,10 +4,10 @@
 
 import PartialIstrue from "./is_true.mdx"
 import PartialIsos from "./is_os.mdx"
+import PartialIsin from "./is_in.mdx"
 import PartialIsequal from "./is_equal.mdx"
 import PartialIsempty from "./is_empty.mdx"
 import PartialIsdependency from "./is_dependency.mdx"
-import PartialIsin from "./is_in.mdx"
 
 <PartialIsdependency />
 <PartialIsempty />

--- a/docs/pages/configuration/_partials/functions/group_checks_global.mdx
+++ b/docs/pages/configuration/_partials/functions/group_checks_global.mdx
@@ -4,10 +4,10 @@
 
 import PartialIstrue from "./is_true.mdx"
 import PartialIsos from "./is_os.mdx"
+import PartialIsin from "./is_in.mdx"
 import PartialIsequal from "./is_equal.mdx"
 import PartialIsempty from "./is_empty.mdx"
 import PartialIsdependency from "./is_dependency.mdx"
-import PartialIsin from "./is_in.mdx"
 
 <PartialIsdependency />
 <PartialIsempty />

--- a/docs/pages/configuration/_partials/functions/group_checks_global.mdx
+++ b/docs/pages/configuration/_partials/functions/group_checks_global.mdx
@@ -7,9 +7,7 @@ import PartialIsos from "./is_os.mdx"
 import PartialIsin from "./is_in.mdx"
 import PartialIsequal from "./is_equal.mdx"
 import PartialIsempty from "./is_empty.mdx"
-import PartialIsdependency from "./is_dependency.mdx"
 
-<PartialIsdependency />
 <PartialIsempty />
 <PartialIsequal />
 <PartialIsin />

--- a/docs/pages/configuration/_partials/functions/group_checks_pipeline.mdx
+++ b/docs/pages/configuration/_partials/functions/group_checks_pipeline.mdx
@@ -1,0 +1,9 @@
+<div className="group" data-group="checks_pipeline">
+<div className="group-name">Checks</div>
+
+
+import PartialIsdependency from "./is_dependency.mdx"
+
+<PartialIsdependency />
+
+</div>

--- a/docs/pages/configuration/_partials/functions/is_dependency.mdx
+++ b/docs/pages/configuration/_partials/functions/is_dependency.mdx
@@ -3,9 +3,9 @@
 <details className="config-field -function" data-expandable="false">
 <summary>
 
-### `is_dependency` <span className="config-field-type"></span> <span className="config-field-enum"></span> <span className="config-field-default -return">bool</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_dependency}
+### `is_dependency` <span className="config-field-type"></span> <span className="config-field-enum"></span> <span className="config-field-default -return">int</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_dependency}
 
-Returns true if the pipeline currently being executed is run because the project is a dependency of another project
+Returns exit code 0 if the pipeline currently being executed is run because the project is a dependency of another project
 
 </summary>
 

--- a/docs/pages/configuration/_partials/functions/is_dependency.mdx
+++ b/docs/pages/configuration/_partials/functions/is_dependency.mdx
@@ -3,7 +3,7 @@
 <details className="config-field -function" data-expandable="false">
 <summary>
 
-### `is_dependency` <span className="config-field-type"></span> <span className="config-field-enum"></span> <span className="config-field-default -return">int</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_dependency}
+### `is_dependency` <span className="config-field-type"></span> <span className="config-field-enum"></span> <span className="config-field-default -return">int</span> <span className="config-field-required" data-required="true">pipeline only</span>  {#is_dependency}
 
 Returns exit code 0 if the pipeline currently being executed is run because the project is a dependency of another project
 

--- a/docs/pages/configuration/_partials/functions/is_empty.mdx
+++ b/docs/pages/configuration/_partials/functions/is_empty.mdx
@@ -3,9 +3,9 @@
 <details className="config-field -function" data-expandable="false">
 <summary>
 
-### `is_empty` <span className="config-field-type">[value]</span> <span className="config-field-enum"></span> <span className="config-field-default -return">bool</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_empty}
+### `is_empty` <span className="config-field-type">[value]</span> <span className="config-field-enum"></span> <span className="config-field-default -return">int</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_empty}
 
-Returns true if the value of the argument is empty string
+Returns exit code 0 if the value of the argument is empty string
 
 </summary>
 

--- a/docs/pages/configuration/_partials/functions/is_equal.mdx
+++ b/docs/pages/configuration/_partials/functions/is_equal.mdx
@@ -3,9 +3,9 @@
 <details className="config-field -function" data-expandable="false">
 <summary>
 
-### `is_equal` <span className="config-field-type">[value-1] [value-2]</span> <span className="config-field-enum"></span> <span className="config-field-default -return">bool</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_equal}
+### `is_equal` <span className="config-field-type">[value-1] [value-2]</span> <span className="config-field-enum"></span> <span className="config-field-default -return">int</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_equal}
 
-Returns true if the values of both arguments provided are equal
+Returns exit code 0 if the values of both arguments provided are equal
 
 </summary>
 

--- a/docs/pages/configuration/_partials/functions/is_in.mdx
+++ b/docs/pages/configuration/_partials/functions/is_in.mdx
@@ -3,9 +3,9 @@
 <details className="config-field -function" data-expandable="false">
 <summary>
 
-### `is_in` <span className="config-field-type">[value-1] [value-2]</span> <span className="config-field-enum"></span> <span className="config-field-default -return">bool</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_in}
+### `is_in` <span className="config-field-type">[value-1] [value-2]</span> <span className="config-field-enum"></span> <span className="config-field-default -return">int</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_in}
 
-Returns true if value of the first argument can be found in the second argument (second argument beeing a blank-separated list of strings e.g `"bananas apples peaches"`)
+Returns exit code 0 if the value of the first argument can be found in the second argument (second argument being a blank-separated list of strings e.g `"bananas apples peaches"`)
 
 </summary>
 

--- a/docs/pages/configuration/_partials/functions/is_os.mdx
+++ b/docs/pages/configuration/_partials/functions/is_os.mdx
@@ -3,9 +3,9 @@
 <details className="config-field -function" data-expandable="false">
 <summary>
 
-### `is_os` <span className="config-field-type">[os]</span> <span className="config-field-enum"><span>darwin linux windows aix android dragonfly freebsd hurd illumos ios js nacl netbsd openbsd plan9 solaris zos</span></span> <span className="config-field-default -return">bool</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_os}
+### `is_os` <span className="config-field-type">[os]</span> <span className="config-field-enum"><span>darwin linux windows aix android dragonfly freebsd hurd illumos ios js nacl netbsd openbsd plan9 solaris zos</span></span> <span className="config-field-default -return">int</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_os}
 
-Returns true if the current operating system equals the value provided as argument
+Returns exit code 0 if the current operating system equals the value provided as argument
 
 </summary>
 

--- a/docs/pages/configuration/_partials/functions/is_true.mdx
+++ b/docs/pages/configuration/_partials/functions/is_true.mdx
@@ -3,9 +3,9 @@
 <details className="config-field -function" data-expandable="false">
 <summary>
 
-### `is_true` <span className="config-field-type">[value]</span> <span className="config-field-enum"></span> <span className="config-field-default -return">bool</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_true}
+### `is_true` <span className="config-field-type">[value]</span> <span className="config-field-enum"></span> <span className="config-field-default -return">int</span> <span className="config-field-required" data-required="false">pipeline only</span>  {#is_true}
 
-Returns true if the value of the argument is "true"
+Returns exit code 0 if the value of the argument is "true"
 
 </summary>
 

--- a/gendocs.sh
+++ b/gendocs.sh
@@ -6,3 +6,4 @@ set -o nounset
 go run ./docs/hack/cli/main.go
 go run ./docs/hack/config/partials/main.go
 go run ./docs/hack/config/schemas/main.go
+go run ./docs/hack/functions/main.go


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind documentation

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Moves `is_dependency` from the "Global Functions" section of the [built-in functions list](http://localhost:8000/docs/configuration/functions/#built-in-functions) to the "Pipeline-Only Functions" section (`is_dependency` is pipeline-only).

**Please provide a short message that should be published in the DevSpace release notes**
Updated classification of `is_dependency` in documentation.
