### PR TITLE
fix: disable upx for linux/arm64

### DIFF
--- a/hack/build-all.bash
+++ b/hack/build-all.bash
@@ -61,7 +61,8 @@ upx "${DEVSPACE_ROOT}/release/devspacehelper" #compress devspacehelper
 shasum -a 256 "${DEVSPACE_ROOT}/release/devspacehelper" > "${DEVSPACE_ROOT}/release/devspacehelper".sha256
 
 GOARCH=arm64 GOOS=linux go build -ldflags "-s -w -X github.com/loft-sh/devspace/helper/cmd.version=${VERSION}" -o "${DEVSPACE_ROOT}/release/devspacehelper-arm64" helper/main.go
-upx "${DEVSPACE_ROOT}/release/devspacehelper-arm64" #compress devspacehelper
+# FIXME: this is not working for any number of arguments/flags
+# upx "${DEVSPACE_ROOT}/release/devspacehelper-arm64" #compress devspacehelper
 shasum -a 256 "${DEVSPACE_ROOT}/release/devspacehelper-arm64" > "${DEVSPACE_ROOT}/release/devspacehelper-arm64".sha256
 
 # build bin data


### PR DESCRIPTION
This is a mitigation for https://github.com/devspace-sh/devspace/issues/2448#issuecomment-1851824126

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2448 


**Please provide a short message that should be published in the DevSpace release notes**
Disables upx binary compression for devspace-helper on linux/arm64. It causes crashes when >500 env vars or flags are present (combined).

**What else do we need to know?** 
