### PR TITLE
restart helper: give container process some time to shutdown

### DIFF
--- a/helper/util/restart_linux.go
+++ b/helper/util/restart_linux.go
@@ -11,8 +11,10 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/loft-sh/devspace/helper/util/stderrlog"
 	"github.com/loft-sh/devspace/pkg/devspace/build/builder/restart"
 	"github.com/pkg/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 type containerRestarter struct {
@@ -69,8 +71,23 @@ func (*containerRestarter) RestartContainer() error {
 	}
 
 	// kill the process group
-	_ = syscall.Kill(-pgid, syscall.SIGINT)
-	time.Sleep(2000)
-	_ = syscall.Kill(-pgid, syscall.SIGKILL)
+	procPath := "/proc/" + strconv.Itoa(pgid)
+
+	for _, sig := range []syscall.Signal{syscall.SIGINT, syscall.SIGTERM, syscall.SIGKILL} {
+		stderrlog.Infof("Sending %s signal...", sig.String())
+		err = syscall.Kill(-pgid, sig)
+		if err != nil {
+			return nil
+		}
+		err = wait.PollImmediate(time.Second, 5*time.Second, func() (done bool, err error) {
+			_, err = os.Stat(procPath)
+			return os.IsNotExist(err), nil
+		})
+		if err == nil {
+			return nil
+		}
+	}
+
+	stderrlog.Errorf("Timeout waiting for the process to terminate")
 	return nil
 }


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
resolves #2788

**Please provide a short message that should be published in the DevSpace release notes**
The helper restart command would wait for 2 microseconds (2000 nanoseconds, supposedly meant to be 2 seconds) between sending SIGINT and SIGKILL to the subcommand. Changed this to send SIGINT, SIGTERM and SIGKILL with five seconds in between, checking for process termination.

**What else do we need to know?** 
