### PR TITLE
fix: treat pipeline flag defaults consistently when used as command f…

### DIFF
--- a/docs/pages/configuration/pipelines/README.mdx
+++ b/docs/pages/configuration/pipelines/README.mdx
@@ -326,8 +326,8 @@ pipelines:
       short: e
       type: stringArray
     run: |-
-      extraEnv=$(get_flag "env")    # Retrieve the value of the `env` flag and store it in a variable
-      echo ${extraEnv[1]}
+      extraEnv=($(get_flag "env"))    # Retrieve the value of the `env` flag and store it in an array variable
+      echo ${extraEnv[0]}             # Arrays are zero indexed
 
       TERMINAL_ENABLED=true
       if [ $(get_flag "logs") == "true" ]; then     # Test if --logs/-l flag is used or not

--- a/e2e/tests/pipelines/testdata/flags/dep1.yaml
+++ b/e2e/tests/pipelines/testdata/flags/dep1.yaml
@@ -35,3 +35,15 @@ pipelines:
       echo $(get_flag test3) > dep1-test2.txt
       echo $(get_flag profile) > dep1-dev-profile.txt
       run_pipelines other --set-flag other2=false
+
+  array:
+    flags:
+      - name: arr
+        type: stringArray
+        default:
+          - one
+          - two
+    run: |-
+      arr=($(get_flag arr))
+      echo -n ${arr[0]} > arr-0.txt
+      echo -n ${arr[1]} > arr-1.txt

--- a/e2e/tests/pipelines/testdata/flags/devspace.yaml
+++ b/e2e/tests/pipelines/testdata/flags/devspace.yaml
@@ -15,6 +15,11 @@ pipelines:
         default: true
       - name: other3
         default: true
+      - name: other4
+        type: stringArray
+        default:
+          - one
+          - two
     run: |-
       if get_flag test; then
         exit 1
@@ -24,6 +29,22 @@ pipelines:
       echo $(get_flag other2) > other2.txt
       echo $(get_flag other3) > other3.txt
       echo $(get_flag profile) > other-profile.txt
+      
+      other4=($(get_flag other4))
+      echo ${other4[0]} > other4-0.txt
+      echo ${other4[1]} > other4-1.txt
+
+  other-override:
+    run: |-
+      run_pipelines other --set-flag other4=five --set-flag other4=six
+
+  arr-dep1:
+    run: |-
+      run_dependency_pipelines dep1 --pipeline array
+
+  arr-dep1-override:
+    run: |-
+      run_dependency_pipelines dep1 --pipeline array --set-flag arr=three
 
   dev:
     flags:

--- a/pkg/devspace/pipeline/flags.go
+++ b/pkg/devspace/pipeline/flags.go
@@ -1,0 +1,52 @@
+package pipeline
+
+import (
+	"fmt"
+
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+)
+
+func GetDefaultValue(pipelineFlag latest.PipelineFlag) (interface{}, error) {
+	var ok bool
+
+	switch pipelineFlag.Type {
+	case "", latest.PipelineFlagTypeBoolean:
+		val := false
+		if pipelineFlag.Default != nil {
+			val, ok = pipelineFlag.Default.(bool)
+			if !ok {
+				return nil, fmt.Errorf(" default is not a boolean")
+			}
+		}
+		return val, nil
+	case latest.PipelineFlagTypeString:
+		val := ""
+		if pipelineFlag.Default != nil {
+			val, ok = pipelineFlag.Default.(string)
+			if !ok {
+				return nil, fmt.Errorf("default is not a string")
+			}
+		}
+		return val, nil
+	case latest.PipelineFlagTypeInteger:
+		val := 0
+		if pipelineFlag.Default != nil {
+			val, ok = pipelineFlag.Default.(int)
+			if !ok {
+				return nil, fmt.Errorf("default is not an integer")
+			}
+		}
+		return val, nil
+	case latest.PipelineFlagTypeStringArray:
+		val := []string{}
+		if pipelineFlag.Default != nil {
+			val, ok = pipelineFlag.Default.([]string)
+			if !ok {
+				return nil, fmt.Errorf("default is not a string array")
+			}
+		}
+		return val, nil
+	}
+
+	return nil, fmt.Errorf("unsupported flag type")
+}

--- a/pkg/devspace/pipeline/pipeline.go
+++ b/pkg/devspace/pipeline/pipeline.go
@@ -423,22 +423,44 @@ func (p *pipeline) startNewDependency(ctx devspacecontext.Context, dependency ty
 }
 
 func applyFlags(ctx devspacecontext.Context, pipeline *latest.Pipeline, setFlags []string) (devspacecontext.Context, error) {
-	newFlags := map[string]string{}
+	defaultFlags := map[string]string{}
 	for _, flag := range pipeline.Flags {
 		val, err := GetDefaultValue(flag)
 		if err != nil {
 			return nil, err
 		}
 
-		newFlags[flag.Name] = fmt.Sprintf("%v", val)
+		switch flag.Type {
+		case latest.PipelineFlagTypeStringArray:
+			defaultFlags[flag.Name] = fmt.Sprintf("%v", strings.Join(val.([]string), " "))
+		default:
+			defaultFlags[flag.Name] = fmt.Sprintf("%v", val)
+		}
 	}
+
+	newFlags := map[string]string{}
 	for _, v := range setFlags {
 		splitted := strings.Split(v, "=")
 		if len(splitted) <= 1 {
 			return nil, fmt.Errorf("error parsing flag %s: expected format flag=value", v)
 		}
 
-		newFlags[splitted[0]] = strings.Join(splitted[1:], "=")
+		flagName := splitted[0]
+		flagVal := strings.Join(splitted[1:], "=")
+		flagVals := strings.Join(strings.Split(flagVal, ","), " ")
+
+		if newFlags[flagName] != "" {
+			newFlags[flagName] = strings.Join([]string{newFlags[flagName], flagVals}, " ")
+		} else {
+			newFlags[flagName] = flagVals
+		}
+
+	}
+
+	for name, value := range defaultFlags {
+		if _, ok := newFlags[name]; !ok {
+			newFlags[name] = value
+		}
 	}
 
 	return ctx.WithContext(values.WithFlagsMap(ctx.Context(), newFlags)), nil


### PR DESCRIPTION
…lags or pipeline flags

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves ENG-2735

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would treat pipeline flag default values differently when used as command flags vs pipeline flags.
