### PR TITLE
fix: check / wake up kube context if defined when running commands

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/pipeline/env"
 	"mvdan.cc/sh/v3/expand"
 
@@ -251,9 +252,11 @@ func (cmd *RunCmd) LoadCommandsConfig(f factory.Factory, configLoader loader.Con
 
 	// verify client connectivity / authn / authz
 	if client != nil {
-		_, err = client.KubeClient().Discovery().ServerVersion()
+		// If the current kube context or namespace is different than old,
+		// show warnings and reset kube client if necessary
+		client, err = kubectl.CheckKubeContext(client, localCache, false, false, false, log)
 		if err != nil {
-			log.Debugf("Unable to discover server version: %v", err)
+			log.Debugf("Unable to verify kube context %v", err)
 			client = nil
 		}
 	}


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bugfix

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would only check kubernetes client connectivity when running commands. It will not behave similarly to other devspace commands when a valid kube config is defined.


**What else do we need to know?** 
