### PR TITLE
docs: remove reference to outdated command

### DIFF
--- a/docs/pages/configuration/dependencies/README.mdx
+++ b/docs/pages/configuration/dependencies/README.mdx
@@ -164,15 +164,6 @@ If DevSpace detects that two projects within the dependency tree define the same
 ### Circular Dependencies
 If DevSpace detects two projects which define each other as dependencies (either directly or via child-dependencies), DevSpace will print a warning showing the problematic dependency path within the dependency tree.
 
-## Useful Commands
-
-### `devspace update dependencies`
-If you want to force DevSpace to update the dependencies (e.g. git fetch & pull), you can run the following command:
-```bash
-devspace update dependencies
-```
-
-
 ## Configuration
 
 <PartialDependenciesConfig/>


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind documentation

**What does this pull request do? Which issues does it resolve?**
Resolves ENG-2956


**Please provide a short message that should be published in the DevSpace release notes**
Removed references to an outdate command in the documentation
