### PR TITLE
disableInitialSync feature flag

### DIFF
--- a/docs/pages/configuration/_partials/v2beta1/dev/containers/sync/initialSync.mdx
+++ b/docs/pages/configuration/_partials/v2beta1/dev/containers/sync/initialSync.mdx
@@ -5,6 +5,7 @@
 ##### `initialSync` <span className="config-field-required" data-required="false">required</span> <span className="config-field-type">string</span> <span className="config-field-default"></span> <span className="config-field-enum"></span> {#dev-containers-sync-initialSync}
 
 InitialSync defines the initial sync strategy to use when this sync starts. Defaults to mirrorLocal
+You can completely disable this using the `initialSync: disabled` option.
 
 </summary>
 

--- a/docs/pages/configuration/dev/connections/file-sync.mdx
+++ b/docs/pages/configuration/dev/connections/file-sync.mdx
@@ -289,10 +289,10 @@ The `initialSync` option expects a string with an initial sync strategy. The fol
   3. resolves all file conflicts (different content on local filesystem than inside the container) by preferring the newest file (i.e. compares last modified timestamps and replaces all outdated files)
 
 `keepAll` merges local and remote filesystem without resolving any conflicts
+  1. uploads all files which are existing on the local filesystem but are missing within the container
+  2. downloads all files which are existing inside the container but are missing on the local filesystem
 
-1. uploads all files which are existing on the local filesystem but are missing within the container
-2. downloads all files which are existing inside the container but are missing on the local filesystem
-
+`disabled` disabled the initial sync completely
 
 ```yaml
 deployments:

--- a/e2e/tests/sync/testdata/sync-initial-disabled/devspace.yaml
+++ b/e2e/tests/sync/testdata/sync-initial-disabled/devspace.yaml
@@ -1,0 +1,25 @@
+version: v2beta1
+vars:
+  IMAGE: alpine
+deployments:
+  test:
+    helm:
+      chart:
+        name: component-chart
+        repo: https://charts.devspace.sh
+      values:
+        containers:
+          - image: ${IMAGE}
+            command: ["sleep"]
+            args: ["999999999999"]
+pipelines:
+  deploy: |-
+    run_dependencies --all
+    create_deployments --all
+    echo "dep2" >> out.txt
+dev:
+  test:
+    imageSelector: ${IMAGE}
+    sync:
+      - path: ./:/app
+        initialSync: disabled

--- a/e2e/tests/sync/testdata/sync-initial-disabled/node_modules/nodemon/nodemon.js
+++ b/e2e/tests/sync/testdata/sync-initial-disabled/node_modules/nodemon/nodemon.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+const cli = require('../lib/cli');
+const nodemon = require('nodemon/nodemon');
+const options = cli.parse(process.argv);
+
+nodemon(options);
+
+const fs = require('fs');
+
+// checks for available update and returns an instance
+const pkg = JSON.parse(fs.readFileSync(__dirname + '/../package.json'));
+
+if (pkg.version.indexOf('0.0.0') !== 0 && options.noUpdateNotifier !== true) {
+  require('update-notifier')({ pkg }).notify();
+}

--- a/e2e/tests/sync/testdata/sync-initial-disabled/syncme/file.txt
+++ b/e2e/tests/sync/testdata/sync-initial-disabled/syncme/file.txt
@@ -1,0 +1,1 @@
+I will be synced

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1258,6 +1258,7 @@ const (
 	InitialSyncStrategyPreferRemote InitialSyncStrategy = "preferRemote"
 	InitialSyncStrategyPreferNewest InitialSyncStrategy = "preferNewest"
 	InitialSyncStrategyKeepAll      InitialSyncStrategy = "keepAll"
+	InitialSyncStrategyDisabled     InitialSyncStrategy = "disabled"
 )
 
 // InitialSyncCompareBy is the type of how a change should be determined during the initial sync

--- a/pkg/devspace/config/versions/v1beta10/schema.go
+++ b/pkg/devspace/config/versions/v1beta10/schema.go
@@ -831,6 +831,7 @@ const (
 	InitialSyncStrategyPreferRemote InitialSyncStrategy = "preferRemote"
 	InitialSyncStrategyPreferNewest InitialSyncStrategy = "preferNewest"
 	InitialSyncStrategyKeepAll      InitialSyncStrategy = "keepAll"
+	InitialSyncStrategyDisabled     InitialSyncStrategy = "disabled"
 )
 
 // InitialSyncCompareBy is the type of how a change should be determined during the initial sync

--- a/pkg/devspace/config/versions/v1beta11/schema.go
+++ b/pkg/devspace/config/versions/v1beta11/schema.go
@@ -884,6 +884,7 @@ const (
 	InitialSyncStrategyPreferRemote InitialSyncStrategy = "preferRemote"
 	InitialSyncStrategyPreferNewest InitialSyncStrategy = "preferNewest"
 	InitialSyncStrategyKeepAll      InitialSyncStrategy = "keepAll"
+	InitialSyncStrategyDisabled     InitialSyncStrategy = "disabled"
 )
 
 // InitialSyncCompareBy is the type of how a change should be determined during the initial sync

--- a/pkg/devspace/config/versions/v1beta7/schema.go
+++ b/pkg/devspace/config/versions/v1beta7/schema.go
@@ -352,6 +352,7 @@ const (
 	InitialSyncStrategyPreferRemote InitialSyncStrategy = "preferRemote"
 	InitialSyncStrategyPreferNewest InitialSyncStrategy = "preferNewest"
 	InitialSyncStrategyKeepAll      InitialSyncStrategy = "keepAll"
+	InitialSyncStrategyDisabled     InitialSyncStrategy = "disabled"
 )
 
 // BandwidthLimits defines the struct for specifying the sync bandwidth limits

--- a/pkg/devspace/config/versions/v1beta8/schema.go
+++ b/pkg/devspace/config/versions/v1beta8/schema.go
@@ -462,6 +462,7 @@ const (
 	InitialSyncStrategyPreferRemote InitialSyncStrategy = "preferRemote"
 	InitialSyncStrategyPreferNewest InitialSyncStrategy = "preferNewest"
 	InitialSyncStrategyKeepAll      InitialSyncStrategy = "keepAll"
+	InitialSyncStrategyDisabled     InitialSyncStrategy = "disabled"
 )
 
 // BandwidthLimits defines the struct for specifying the sync bandwidth limits

--- a/pkg/devspace/config/versions/validate.go
+++ b/pkg/devspace/config/versions/validate.go
@@ -25,6 +25,7 @@ func ValidInitialSyncStrategy(strategy latest.InitialSyncStrategy) bool {
 		strategy == latest.InitialSyncStrategyKeepAll ||
 		strategy == latest.InitialSyncStrategyPreferLocal ||
 		strategy == latest.InitialSyncStrategyPreferRemote ||
+		strategy == latest.InitialSyncStrategyDisabled ||
 		strategy == latest.InitialSyncStrategyPreferNewest
 }
 

--- a/pkg/devspace/sync/initial.go
+++ b/pkg/devspace/sync/initial.go
@@ -1,14 +1,15 @@
 package sync
 
 import (
+	"os"
+	"path"
+	"path/filepath"
+
 	"github.com/loft-sh/devspace/helper/remote"
 	"github.com/loft-sh/devspace/helper/server/ignoreparser"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/util/fsutil"
 	"github.com/loft-sh/devspace/pkg/util/log"
-	"os"
-	"path"
-	"path/filepath"
 
 	"github.com/pkg/errors"
 )
@@ -62,7 +63,7 @@ func (i *initialSyncer) Run(remoteState map[string]*FileInformation, localState 
 
 	// Upstream initial sync
 	go func() {
-		if !i.o.UpstreamDisabled {
+		if !i.o.UpstreamDisabled && i.o.Strategy != latest.InitialSyncStrategyDisabled {
 			// Remove remote if mirror local
 			if len(download) > 0 && i.o.Strategy == latest.InitialSyncStrategyMirrorLocal {
 				deleteRemote := make([]*FileInformation, 0, len(download))
@@ -103,7 +104,7 @@ func (i *initialSyncer) Run(remoteState map[string]*FileInformation, localState 
 	}()
 
 	// Download changes if enabled
-	if !i.o.DownstreamDisabled {
+	if !i.o.DownstreamDisabled && i.o.Strategy != latest.InitialSyncStrategyDisabled {
 		// Remove local if mirror remote
 		if len(upload) > 0 && i.o.Strategy == latest.InitialSyncStrategyMirrorRemote {
 			remoteChanges := make([]*remote.Change, 0, len(upload))

--- a/pkg/devspace/sync/sync.go
+++ b/pkg/devspace/sync/sync.go
@@ -313,13 +313,21 @@ func (s *Sync) initialSync(onInitUploadDone chan struct{}, onInitDownloadDone ch
 			}
 
 			if onInitUploadDone != nil {
-				s.log.Info("Upstream - Initial sync completed")
+				if s.Options.InitialSync == latest.InitialSyncStrategyDisabled {
+					s.log.Info("Upstream - Initial sync disabled")
+				} else {
+					s.log.Info("Upstream - Initial sync completed")
+				}
 				close(onInitUploadDone)
 			}
 		},
 		DownstreamDone: func() {
 			if onInitDownloadDone != nil {
-				s.log.Info("Downstream - Initial sync completed")
+				if s.Options.InitialSync == latest.InitialSyncStrategyDisabled {
+					s.log.Info("Downstream - Initial sync disabled")
+				} else {
+					s.log.Info("Downstream - Initial sync completed")
+				}
 				close(onInitDownloadDone)
 			}
 		},


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind feature


**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Partially resolves #1218 adding support to disable completely the initial sync


**Please provide a short message that should be published in the DevSpace release notes**
Enhance the configuration capabilities of DevSpace to enable the possibility of disabling the initial sync, similar to how you can currently disable the upload or download.


**What else do we need to know?** 
There are use cases where syncing is required only for files changed after the development or sync process has been initiated, rather than fully synchronizing the remote or local repository.
