### PR TITLE
fix: better error message for invalid Helm Chart path during init

### DIFF
--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -145,7 +145,7 @@ func (m *manager) AddHelmDeployment(deploymentName string) error {
 				localChartPathRel = localChartPath
 			}
 
-			pathStat, err := os.Stat(localChartPath)
+			pathStat, err := os.Stat(localChartPathRel)
 			if err != nil {
 				return err
 			}
@@ -156,10 +156,15 @@ func (m *manager) AddHelmDeployment(deploymentName string) error {
 				continue
 			}
 
-			if _, err := os.Stat(path.Join(localChartPathRel, "Chart.yaml")); errors.Is(err, os.ErrNotExist) {
+			if _, err := os.Stat(path.Join(localChartPathRel, "Chart.yaml")); err != nil {
 				m.log.WriteString(logrus.InfoLevel, "\n")
-				m.log.Errorf("Local path `%s` is not a Helm chart (Chart.yaml missing)", localChartPathRel)
-				continue
+				if errors.Is(err, os.ErrNotExist) {
+					m.log.Errorf("Local path `%s` is not a Helm chart (Chart.yaml missing)", localChartPathRel)
+					continue
+				} else {
+					m.log.Errorf("Encountered unexpected error checking local path `%s`: %s", localChartPathRel, err.Error())
+					continue
+				}
 			}
 
 			helmConfig.Chart.Name = localChartPathRel

--- a/pkg/devspace/configure/deployment.go
+++ b/pkg/devspace/configure/deployment.go
@@ -145,8 +145,18 @@ func (m *manager) AddHelmDeployment(deploymentName string) error {
 				localChartPathRel = localChartPath
 			}
 
-			stat, err := os.Stat(path.Join(localChartPathRel, "Chart.yaml"))
-			if err != nil || stat.IsDir() {
+			pathStat, err := os.Stat(localChartPath)
+			if err != nil {
+				return err
+			}
+
+			if !pathStat.IsDir() {
+				m.log.WriteString(logrus.InfoLevel, "\n")
+				m.log.Errorf("Local path `%s` is not a Helm chart (path is not a directory)", localChartPathRel)
+				continue
+			}
+
+			if _, err := os.Stat(path.Join(localChartPathRel, "Chart.yaml")); errors.Is(err, os.ErrNotExist) {
 				m.log.WriteString(logrus.InfoLevel, "\n")
 				m.log.Errorf("Local path `%s` is not a Helm chart (Chart.yaml missing)", localChartPathRel)
 				continue


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?**
Resolves #2838. See that issue for details.

New error message displayed when following the repro steps documented in the issue:

```
~/helm-test > helm create foo
Creating foo
~/helm-test > ls
foo
~/helm-test > cd foo
~/helm-test/foo > l
charts/  Chart.yaml  templates/  values.yaml
~/helm-test/foo > cd ..
~/helm-test > alias devspace=/home/matt/code/github.com/mattwelke/devspace/devspace
~/helm-test > devspace init


     %########%      
     %###########%       ____                 _____                      
         %#########%    |  _ \   ___ __   __ / ___/  ____    ____   ____ ___ 
         %#########%    | | | | / _ \\ \ / / \___ \ |  _ \  / _  | / __// _ \
     %#############%    | |_| |(  __/ \ V /  ____) )| |_) )( (_| |( (__(  __/
     %#############%    |____/  \___|  \_/   \____/ |  __/  \__,_| \___\\___|
 %###############%                                  |_|
 %###########%


info Detecting programming language...

? Select the programming language of this project other

? How do you want to deploy this project? 

? Do you already have a Helm chart for this project? Yes

? Which Helm chart do you want to use? 

? Please enter the relative path to your local Helm chart (e.g. ./chart) foo/Chart.yaml

error Local path `foo/Chart.yaml` is not a Helm chart (path is not a directory)

? Which Helm chart do you want to use? 

? Please enter the relative path to your local Helm chart (e.g. ./chart) .

error Local path `.` is not a Helm chart (Chart.yaml missing)

? Which Helm chart do you want to use? 

? Please enter the relative path to your local Helm chart (e.g. ./chart) foo

? Do you want to develop this project with DevSpace or just deploy it?  [Use arrows to move, type to filter]  [Use arrows to move, type to filter]
> I want to develop this project and my current working dir contains the source code
  I just want to deploy this project
```

Note the "path is not a directory".

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace's error message given a path to a file within a Chart directory instead of the Chart directory itself was unclear

**What else do we need to know?** 

I didn't see any tests that called the function I changed, so I did not update or add any tests. But I did build the binary using the instructions in CONTRIBUTING.md and manually tested it. I used the built binary to produce the new command output above.

I followed instructions in CONTRIBUTING.md to run unit tests and integration tests. Integration tests did not pass, but I'm creating this PR to see if it was just my local env that prevented them from passing.
