### PR TITLE
fix: honor --no-warn and --switch-context flags when running commands

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -254,7 +254,7 @@ func (cmd *RunCmd) LoadCommandsConfig(f factory.Factory, configLoader loader.Con
 	if client != nil {
 		// If the current kube context or namespace is different than old,
 		// show warnings and reset kube client if necessary
-		client, err = kubectl.CheckKubeContext(client, localCache, false, false, false, log)
+		client, err = kubectl.CheckKubeContext(client, localCache, cmd.NoWarn, cmd.SwitchContext, false, log)
 		if err != nil {
 			log.Debugf("Unable to verify kube context %v", err)
 			client = nil


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #2837
resolves DSP-6


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace would always prompt on the 'default' namespace when running commands.

