### PR TITLE
chore: update golangci-lint configuration to remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,19 +1,21 @@
 run:
   timeout: 10m
-  skip-dirs:
+
+issues:
+  exclude-dirs:
   - hack/
   - docs/
 
 linters:
   disable-all:  true
   enable:
-    - deadcode
+    # - deadcode # deprecated https://github.com/golangci/golangci-lint/issues/1841
     - gosimple
     - govet
     - ineffassign
     - misspell
     - unused
-    - varcheck
+    # - varcheck # deprecated https://github.com/golangci/golangci-lint/issues/1841
     - staticcheck
     - errcheck
     # - goimports
@@ -22,7 +24,7 @@ linters:
     - stylecheck
     # - gofmt
     # - golint
-    # - structcheck
+    # - structcheck # deprecated https://github.com/golangci/golangci-lint/issues/1841
   
 linters-settings:
   gofmt:


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
Part of DSP-5


**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where DevSpace builds failed due to deprecated linters.