### PR TITLE
Removes call to SetDefaultScheme, which is not thread safe.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/k0kubun/go-ansi v0.0.0-20180517002512-3bf9e2903213
 	github.com/loft-sh/go-github-selfupdate v1.0.0
 	github.com/loft-sh/loft-util v0.0.9-alpha
-	github.com/loft-sh/notify v0.0.0-20210827094439-0720dcc7feee
+	github.com/loft-sh/notify v0.0.0-20250811133046-d79ab32e79b2
 	github.com/loft-sh/programming-language-detection v0.0.5
 	github.com/loft-sh/utils v0.0.16
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b
@@ -195,7 +195,7 @@ require (
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	golang.org/x/oauth2 v0.30.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/sys v0.34.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/term v0.33.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -337,8 +337,8 @@ github.com/loft-sh/go-github-selfupdate v1.0.0 h1:YS8iSsIWXw3BygBdPK2xDO4K84XYu2
 github.com/loft-sh/go-github-selfupdate v1.0.0/go.mod h1:LDkR6J2QpqQLIMcYvNaSinVwvjPAkg8278oZBPGnrb8=
 github.com/loft-sh/loft-util v0.0.9-alpha h1:kGcyTQWxWHWy7bbjhS8Hsq/JRdlSztAU++anV6P+sqk=
 github.com/loft-sh/loft-util v0.0.9-alpha/go.mod h1:lsjG5Exh5iEf7Z/87nqwkxx3GRQTizFRLGuS1knF6Cg=
-github.com/loft-sh/notify v0.0.0-20210827094439-0720dcc7feee h1:hZ79+pKEbCBrH1dVmgZ4jtFrrDPxgM4zqEP1lHlSnvI=
-github.com/loft-sh/notify v0.0.0-20210827094439-0720dcc7feee/go.mod h1:pq83B8lgfCY7tKdegTTXU6DZxGQkcWMowUTOTpTQmqk=
+github.com/loft-sh/notify v0.0.0-20250811133046-d79ab32e79b2 h1:N3uX7AwEUUwBxt4rgvNIaYzb7cUvxDfjp7tD68yiavo=
+github.com/loft-sh/notify v0.0.0-20250811133046-d79ab32e79b2/go.mod h1:pq83B8lgfCY7tKdegTTXU6DZxGQkcWMowUTOTpTQmqk=
 github.com/loft-sh/programming-language-detection v0.0.5 h1:XiWlxtrf4t6Z7SQiob0JMKaCeMHCP3kWhB80wLt+EMY=
 github.com/loft-sh/programming-language-detection v0.0.5/go.mod h1:QGPQGKr9q1+rQS4OyisS5CPGY1a76SdNaZuk9oy+2cE=
 github.com/loft-sh/utils v0.0.16 h1:XnD6Sb6gRWIHgM34U94dHcQ5MtxN5kAGZQ5eddAxC+c=
@@ -680,8 +680,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
-golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
+golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210503060354-a79de5458b56/go.mod h1:tfny5GFUkzUvx4ps4ajbZsCe5lw1metzhBm9T3x7oIY=

--- a/helper/util/conn.go
+++ b/helper/util/conn.go
@@ -4,23 +4,20 @@ import (
 	"context"
 	"io"
 	"net"
-	
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/resolver"
 )
 
 // NewClientConnection creates a new client connection for the given reader and writer
 func NewClientConnection(reader io.Reader, writer io.Writer) (*grpc.ClientConn, error) {
 	pipe := NewStdStreamJoint(reader, writer, false)
-	
-	resolver.SetDefaultScheme("passthrough")
+
 	// Set up a connection to the server.
-	return grpc.NewClient("",
+	return grpc.NewClient("passthrough:///",
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
 			return pipe, nil
 		}),
-		grpc.WithLocalDNSResolution(),
-		grpc.WithDefaultCallOptions())
+		grpc.WithLocalDNSResolution())
 }

--- a/pkg/devspace/services/sync/controller.go
+++ b/pkg/devspace/services/sync/controller.go
@@ -501,7 +501,7 @@ func (c *controller) initClient(ctx devspacecontext.Context, pod *v1.Pod, arch, 
 	go func() {
 		err := StartStream(ctx.Context(), ctx.KubeClient(), pod, container, upstreamArgs, upStdinReader, upStdoutWriter, true, options.Log)
 		if err != nil {
-			syncClient.Stop(errors.Errorf("Sync - connection lost to pod %s/%s: %v", pod.Namespace, pod.Name, err))
+			syncClient.Stop(errors.Errorf("Downstream Sync - connection lost to pod %s/%s: %v", pod.Namespace, pod.Name, err))
 		}
 	}()
 
@@ -529,7 +529,7 @@ func (c *controller) initClient(ctx devspacecontext.Context, pod *v1.Pod, arch, 
 	go func() {
 		err := StartStream(ctx.Context(), ctx.KubeClient(), pod, container, downstreamArgs, downStdinReader, downStdoutWriter, true, options.Log)
 		if err != nil {
-			syncClient.Stop(errors.Errorf("Sync - connection lost to pod %s/%s: %v", pod.Namespace, pod.Name, err))
+			syncClient.Stop(errors.Errorf("Upstream Sync - connection lost to pod %s/%s: %v", pod.Namespace, pod.Name, err))
 		}
 	}()
 

--- a/vendor/github.com/loft-sh/notify/watcher_fsevents_cgo.go
+++ b/vendor/github.com/loft-sh/notify/watcher_fsevents_cgo.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the MIT license that can be
 // found in the LICENSE file.
 
+//go:build darwin && !kqueue && cgo
 // +build darwin,!kqueue,cgo
 
 package notify
@@ -106,7 +107,7 @@ func gostream(_, info uintptr, n C.size_t, paths, flags, ids uintptr) {
 				ID:    *(*uint64)(unsafe.Pointer(ids + i*offid)),
 			})
 		}
-
+		
 	}
 	fn(ev)
 }
@@ -173,7 +174,7 @@ func (s *stream) Start() error {
 	if ref == nilstream {
 		return errCreate
 	}
-	C.FSEventStreamScheduleWithRunLoop(ref, runloop, C.kCFRunLoopDefaultMode)
+	C.FSEventStreamSetDispatchQueue(ref, C.dispatch_get_main_queue())
 	if C.FSEventStreamStart(ref) == C.Boolean(0) {
 		C.FSEventStreamInvalidate(ref)
 		return errStart

--- a/vendor/golang.org/x/sys/unix/mkerrors.sh
+++ b/vendor/golang.org/x/sys/unix/mkerrors.sh
@@ -349,6 +349,9 @@ struct ltchars {
 #define _HIDIOCGRAWPHYS		HIDIOCGRAWPHYS(_HIDIOCGRAWPHYS_LEN)
 #define _HIDIOCGRAWUNIQ		HIDIOCGRAWUNIQ(_HIDIOCGRAWUNIQ_LEN)
 
+// Renamed in v6.16, commit c6d732c38f93 ("net: ethtool: remove duplicate defines for family info")
+#define ETHTOOL_FAMILY_NAME	ETHTOOL_GENL_NAME
+#define ETHTOOL_FAMILY_VERSION	ETHTOOL_GENL_VERSION
 '
 
 includes_NetBSD='

--- a/vendor/golang.org/x/sys/unix/zerrors_linux.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux.go
@@ -328,6 +328,8 @@ const (
 	AUDIT_KERNEL                                = 0x7d0
 	AUDIT_KERNEL_OTHER                          = 0x524
 	AUDIT_KERN_MODULE                           = 0x532
+	AUDIT_LANDLOCK_ACCESS                       = 0x58f
+	AUDIT_LANDLOCK_DOMAIN                       = 0x590
 	AUDIT_LAST_FEATURE                          = 0x1
 	AUDIT_LAST_KERN_ANOM_MSG                    = 0x707
 	AUDIT_LAST_USER_MSG                         = 0x4af
@@ -492,6 +494,7 @@ const (
 	BPF_F_BEFORE                                = 0x8
 	BPF_F_ID                                    = 0x20
 	BPF_F_NETFILTER_IP_DEFRAG                   = 0x1
+	BPF_F_PREORDER                              = 0x40
 	BPF_F_QUERY_EFFECTIVE                       = 0x1
 	BPF_F_REDIRECT_FLAGS                        = 0x19
 	BPF_F_REPLACE                               = 0x4
@@ -528,6 +531,7 @@ const (
 	BPF_LDX                                     = 0x1
 	BPF_LEN                                     = 0x80
 	BPF_LL_OFF                                  = -0x200000
+	BPF_LOAD_ACQ                                = 0x100
 	BPF_LSH                                     = 0x60
 	BPF_MAJOR_VERSION                           = 0x1
 	BPF_MAXINSNS                                = 0x1000
@@ -555,6 +559,7 @@ const (
 	BPF_RET                                     = 0x6
 	BPF_RSH                                     = 0x70
 	BPF_ST                                      = 0x2
+	BPF_STORE_REL                               = 0x110
 	BPF_STX                                     = 0x3
 	BPF_SUB                                     = 0x10
 	BPF_TAG_SIZE                                = 0x8
@@ -844,9 +849,9 @@ const (
 	DM_UUID_FLAG                                = 0x4000
 	DM_UUID_LEN                                 = 0x81
 	DM_VERSION                                  = 0xc138fd00
-	DM_VERSION_EXTRA                            = "-ioctl (2025-01-17)"
+	DM_VERSION_EXTRA                            = "-ioctl (2025-04-28)"
 	DM_VERSION_MAJOR                            = 0x4
-	DM_VERSION_MINOR                            = 0x31
+	DM_VERSION_MINOR                            = 0x32
 	DM_VERSION_PATCHLEVEL                       = 0x0
 	DT_BLK                                      = 0x6
 	DT_CHR                                      = 0x2
@@ -937,9 +942,6 @@ const (
 	EPOLL_CTL_MOD                               = 0x3
 	EPOLL_IOC_TYPE                              = 0x8a
 	EROFS_SUPER_MAGIC_V1                        = 0xe0f5e1e2
-	ESP_V4_FLOW                                 = 0xa
-	ESP_V6_FLOW                                 = 0xc
-	ETHER_FLOW                                  = 0x12
 	ETHTOOL_BUSINFO_LEN                         = 0x20
 	ETHTOOL_EROMVERS_LEN                        = 0x20
 	ETHTOOL_FAMILY_NAME                         = "ethtool"
@@ -1213,6 +1215,7 @@ const (
 	FAN_EVENT_INFO_TYPE_DFID_NAME               = 0x2
 	FAN_EVENT_INFO_TYPE_ERROR                   = 0x5
 	FAN_EVENT_INFO_TYPE_FID                     = 0x1
+	FAN_EVENT_INFO_TYPE_MNT                     = 0x7
 	FAN_EVENT_INFO_TYPE_NEW_DFID_NAME           = 0xc
 	FAN_EVENT_INFO_TYPE_OLD_DFID_NAME           = 0xa
 	FAN_EVENT_INFO_TYPE_PIDFD                   = 0x4
@@ -1231,9 +1234,12 @@ const (
 	FAN_MARK_IGNORED_SURV_MODIFY                = 0x40
 	FAN_MARK_IGNORE_SURV                        = 0x440
 	FAN_MARK_INODE                              = 0x0
+	FAN_MARK_MNTNS                              = 0x110
 	FAN_MARK_MOUNT                              = 0x10
 	FAN_MARK_ONLYDIR                            = 0x8
 	FAN_MARK_REMOVE                             = 0x2
+	FAN_MNT_ATTACH                              = 0x1000000
+	FAN_MNT_DETACH                              = 0x2000000
 	FAN_MODIFY                                  = 0x2
 	FAN_MOVE                                    = 0xc0
 	FAN_MOVED_FROM                              = 0x40
@@ -1255,6 +1261,7 @@ const (
 	FAN_REPORT_DIR_FID                          = 0x400
 	FAN_REPORT_FD_ERROR                         = 0x2000
 	FAN_REPORT_FID                              = 0x200
+	FAN_REPORT_MNT                              = 0x4000
 	FAN_REPORT_NAME                             = 0x800
 	FAN_REPORT_PIDFD                            = 0x80
 	FAN_REPORT_TARGET_FID                       = 0x1000
@@ -1274,6 +1281,7 @@ const (
 	FIB_RULE_PERMANENT                          = 0x1
 	FIB_RULE_UNRESOLVED                         = 0x4
 	FIDEDUPERANGE                               = 0xc0189436
+	FSCRYPT_ADD_KEY_FLAG_HW_WRAPPED             = 0x1
 	FSCRYPT_KEY_DESCRIPTOR_SIZE                 = 0x8
 	FSCRYPT_KEY_DESC_PREFIX                     = "fscrypt:"
 	FSCRYPT_KEY_DESC_PREFIX_SIZE                = 0x8
@@ -1582,7 +1590,6 @@ const (
 	IPV6_DONTFRAG                               = 0x3e
 	IPV6_DROP_MEMBERSHIP                        = 0x15
 	IPV6_DSTOPTS                                = 0x3b
-	IPV6_FLOW                                   = 0x11
 	IPV6_FREEBIND                               = 0x4e
 	IPV6_HDRINCL                                = 0x24
 	IPV6_HOPLIMIT                               = 0x34
@@ -1633,7 +1640,6 @@ const (
 	IPV6_TRANSPARENT                            = 0x4b
 	IPV6_UNICAST_HOPS                           = 0x10
 	IPV6_UNICAST_IF                             = 0x4c
-	IPV6_USER_FLOW                              = 0xe
 	IPV6_V6ONLY                                 = 0x1a
 	IPV6_VERSION                                = 0x60
 	IPV6_VERSION_MASK                           = 0xf0
@@ -1695,7 +1701,6 @@ const (
 	IP_TTL                                      = 0x2
 	IP_UNBLOCK_SOURCE                           = 0x25
 	IP_UNICAST_IF                               = 0x32
-	IP_USER_FLOW                                = 0xd
 	IP_XFRM_POLICY                              = 0x11
 	ISOFS_SUPER_MAGIC                           = 0x9660
 	ISTRIP                                      = 0x20
@@ -1817,7 +1822,11 @@ const (
 	LANDLOCK_ACCESS_FS_WRITE_FILE               = 0x2
 	LANDLOCK_ACCESS_NET_BIND_TCP                = 0x1
 	LANDLOCK_ACCESS_NET_CONNECT_TCP             = 0x2
+	LANDLOCK_CREATE_RULESET_ERRATA              = 0x2
 	LANDLOCK_CREATE_RULESET_VERSION             = 0x1
+	LANDLOCK_RESTRICT_SELF_LOG_NEW_EXEC_ON      = 0x2
+	LANDLOCK_RESTRICT_SELF_LOG_SAME_EXEC_OFF    = 0x1
+	LANDLOCK_RESTRICT_SELF_LOG_SUBDOMAINS_OFF   = 0x4
 	LANDLOCK_SCOPE_ABSTRACT_UNIX_SOCKET         = 0x1
 	LANDLOCK_SCOPE_SIGNAL                       = 0x2
 	LINUX_REBOOT_CMD_CAD_OFF                    = 0x0
@@ -2493,6 +2502,10 @@ const (
 	PR_FP_EXC_UND                               = 0x40000
 	PR_FP_MODE_FR                               = 0x1
 	PR_FP_MODE_FRE                              = 0x2
+	PR_FUTEX_HASH                               = 0x4e
+	PR_FUTEX_HASH_GET_IMMUTABLE                 = 0x3
+	PR_FUTEX_HASH_GET_SLOTS                     = 0x2
+	PR_FUTEX_HASH_SET_SLOTS                     = 0x1
 	PR_GET_AUXV                                 = 0x41555856
 	PR_GET_CHILD_SUBREAPER                      = 0x25
 	PR_GET_DUMPABLE                             = 0x3
@@ -2652,6 +2665,10 @@ const (
 	PR_TAGGED_ADDR_ENABLE                       = 0x1
 	PR_TASK_PERF_EVENTS_DISABLE                 = 0x1f
 	PR_TASK_PERF_EVENTS_ENABLE                  = 0x20
+	PR_TIMER_CREATE_RESTORE_IDS                 = 0x4d
+	PR_TIMER_CREATE_RESTORE_IDS_GET             = 0x2
+	PR_TIMER_CREATE_RESTORE_IDS_OFF             = 0x0
+	PR_TIMER_CREATE_RESTORE_IDS_ON              = 0x1
 	PR_TIMING_STATISTICAL                       = 0x0
 	PR_TIMING_TIMESTAMP                         = 0x1
 	PR_TSC_ENABLE                               = 0x1
@@ -2732,6 +2749,7 @@ const (
 	PTRACE_SETREGSET                            = 0x4205
 	PTRACE_SETSIGINFO                           = 0x4203
 	PTRACE_SETSIGMASK                           = 0x420b
+	PTRACE_SET_SYSCALL_INFO                     = 0x4212
 	PTRACE_SET_SYSCALL_USER_DISPATCH_CONFIG     = 0x4210
 	PTRACE_SINGLESTEP                           = 0x9
 	PTRACE_SYSCALL                              = 0x18
@@ -2982,6 +3000,7 @@ const (
 	RTPROT_NTK                                  = 0xf
 	RTPROT_OPENR                                = 0x63
 	RTPROT_OSPF                                 = 0xbc
+	RTPROT_OVN                                  = 0x54
 	RTPROT_RA                                   = 0x9
 	RTPROT_REDIRECT                             = 0x1
 	RTPROT_RIP                                  = 0xbd
@@ -3336,7 +3355,7 @@ const (
 	TASKSTATS_GENL_NAME                         = "TASKSTATS"
 	TASKSTATS_GENL_VERSION                      = 0x1
 	TASKSTATS_TYPE_MAX                          = 0x6
-	TASKSTATS_VERSION                           = 0xf
+	TASKSTATS_VERSION                           = 0x10
 	TCIFLUSH                                    = 0x0
 	TCIOFF                                      = 0x2
 	TCIOFLUSH                                   = 0x2
@@ -3406,8 +3425,6 @@ const (
 	TCP_TX_DELAY                                = 0x25
 	TCP_ULP                                     = 0x1f
 	TCP_USER_TIMEOUT                            = 0x12
-	TCP_V4_FLOW                                 = 0x1
-	TCP_V6_FLOW                                 = 0x5
 	TCP_WINDOW_CLAMP                            = 0xa
 	TCP_ZEROCOPY_RECEIVE                        = 0x23
 	TFD_TIMER_ABSTIME                           = 0x1
@@ -3530,8 +3547,6 @@ const (
 	UDP_NO_CHECK6_RX                            = 0x66
 	UDP_NO_CHECK6_TX                            = 0x65
 	UDP_SEGMENT                                 = 0x67
-	UDP_V4_FLOW                                 = 0x2
-	UDP_V6_FLOW                                 = 0x6
 	UMOUNT_NOFOLLOW                             = 0x8
 	USBDEVICE_SUPER_MAGIC                       = 0x9fa2
 	UTIME_NOW                                   = 0x3fffffff
@@ -3574,7 +3589,7 @@ const (
 	WDIOS_TEMPPANIC                             = 0x4
 	WDIOS_UNKNOWN                               = -0x1
 	WEXITED                                     = 0x4
-	WGALLOWEDIP_A_MAX                           = 0x3
+	WGALLOWEDIP_A_MAX                           = 0x4
 	WGDEVICE_A_MAX                              = 0x8
 	WGPEER_A_MAX                                = 0xa
 	WG_CMD_MAX                                  = 0x1
@@ -3688,6 +3703,7 @@ const (
 	XDP_SHARED_UMEM                             = 0x1
 	XDP_STATISTICS                              = 0x7
 	XDP_TXMD_FLAGS_CHECKSUM                     = 0x2
+	XDP_TXMD_FLAGS_LAUNCH_TIME                  = 0x4
 	XDP_TXMD_FLAGS_TIMESTAMP                    = 0x1
 	XDP_TX_METADATA                             = 0x2
 	XDP_TX_RING                                 = 0x3

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_386.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0xfd12
 	ECCGETLAYOUT                     = 0x81484d11
 	ECCGETSTATS                      = 0x80104d12
 	ECHOCTL                          = 0x200
@@ -360,6 +361,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x10
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x11

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_amd64.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0xfd12
 	ECCGETLAYOUT                     = 0x81484d11
 	ECCGETSTATS                      = 0x80104d12
 	ECHOCTL                          = 0x200
@@ -361,6 +362,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x10
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x11

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0xfd12
 	ECCGETLAYOUT                     = 0x81484d11
 	ECCGETSTATS                      = 0x80104d12
 	ECHOCTL                          = 0x200
@@ -366,6 +367,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x10
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x11

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_arm64.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0xfd12
 	ECCGETLAYOUT                     = 0x81484d11
 	ECCGETSTATS                      = 0x80104d12
 	ECHOCTL                          = 0x200
@@ -359,6 +360,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x10
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x11

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_loong64.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0xfd12
 	ECCGETLAYOUT                     = 0x81484d11
 	ECCGETSTATS                      = 0x80104d12
 	ECHOCTL                          = 0x200
@@ -353,6 +354,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x10
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x11

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0x2000fd12
 	ECCGETLAYOUT                     = 0x41484d11
 	ECCGETSTATS                      = 0x40104d12
 	ECHOCTL                          = 0x200
@@ -359,6 +360,7 @@ const (
 	SO_OOBINLINE                     = 0x100
 	SO_PASSCRED                      = 0x11
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x12

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0x2000fd12
 	ECCGETLAYOUT                     = 0x41484d11
 	ECCGETSTATS                      = 0x40104d12
 	ECHOCTL                          = 0x200
@@ -359,6 +360,7 @@ const (
 	SO_OOBINLINE                     = 0x100
 	SO_PASSCRED                      = 0x11
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x12

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mips64le.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0x2000fd12
 	ECCGETLAYOUT                     = 0x41484d11
 	ECCGETSTATS                      = 0x40104d12
 	ECHOCTL                          = 0x200
@@ -359,6 +360,7 @@ const (
 	SO_OOBINLINE                     = 0x100
 	SO_PASSCRED                      = 0x11
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x12

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_mipsle.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0x2000fd12
 	ECCGETLAYOUT                     = 0x41484d11
 	ECCGETSTATS                      = 0x40104d12
 	ECHOCTL                          = 0x200
@@ -359,6 +360,7 @@ const (
 	SO_OOBINLINE                     = 0x100
 	SO_PASSCRED                      = 0x11
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x12

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x300
 	CSIZE                            = 0x300
 	CSTOPB                           = 0x400
+	DM_MPATH_PROBE_PATHS             = 0x2000fd12
 	ECCGETLAYOUT                     = 0x41484d11
 	ECCGETSTATS                      = 0x40104d12
 	ECHOCTL                          = 0x40
@@ -414,6 +415,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x14
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x15

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x300
 	CSIZE                            = 0x300
 	CSTOPB                           = 0x400
+	DM_MPATH_PROBE_PATHS             = 0x2000fd12
 	ECCGETLAYOUT                     = 0x41484d11
 	ECCGETSTATS                      = 0x40104d12
 	ECHOCTL                          = 0x40
@@ -418,6 +419,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x14
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x15

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_ppc64le.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x300
 	CSIZE                            = 0x300
 	CSTOPB                           = 0x400
+	DM_MPATH_PROBE_PATHS             = 0x2000fd12
 	ECCGETLAYOUT                     = 0x41484d11
 	ECCGETSTATS                      = 0x40104d12
 	ECHOCTL                          = 0x40
@@ -418,6 +419,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x14
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x15

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_riscv64.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0xfd12
 	ECCGETLAYOUT                     = 0x81484d11
 	ECCGETSTATS                      = 0x80104d12
 	ECHOCTL                          = 0x200
@@ -350,6 +351,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x10
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x11

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_s390x.go
@@ -68,6 +68,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0xfd12
 	ECCGETLAYOUT                     = 0x81484d11
 	ECCGETSTATS                      = 0x80104d12
 	ECHOCTL                          = 0x200
@@ -422,6 +423,7 @@ const (
 	SO_OOBINLINE                     = 0xa
 	SO_PASSCRED                      = 0x10
 	SO_PASSPIDFD                     = 0x4c
+	SO_PASSRIGHTS                    = 0x53
 	SO_PASSSEC                       = 0x22
 	SO_PEEK_OFF                      = 0x2a
 	SO_PEERCRED                      = 0x11

--- a/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
+++ b/vendor/golang.org/x/sys/unix/zerrors_linux_sparc64.go
@@ -71,6 +71,7 @@ const (
 	CS8                              = 0x30
 	CSIZE                            = 0x30
 	CSTOPB                           = 0x40
+	DM_MPATH_PROBE_PATHS             = 0x2000fd12
 	ECCGETLAYOUT                     = 0x41484d11
 	ECCGETSTATS                      = 0x40104d12
 	ECHOCTL                          = 0x200
@@ -461,6 +462,7 @@ const (
 	SO_OOBINLINE                     = 0x100
 	SO_PASSCRED                      = 0x2
 	SO_PASSPIDFD                     = 0x55
+	SO_PASSRIGHTS                    = 0x5c
 	SO_PASSSEC                       = 0x1f
 	SO_PEEK_OFF                      = 0x26
 	SO_PEERCRED                      = 0x40

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_386.go
@@ -462,4 +462,5 @@ const (
 	SYS_GETXATTRAT                   = 464
 	SYS_LISTXATTRAT                  = 465
 	SYS_REMOVEXATTRAT                = 466
+	SYS_OPEN_TREE_ATTR               = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_amd64.go
@@ -385,4 +385,5 @@ const (
 	SYS_GETXATTRAT              = 464
 	SYS_LISTXATTRAT             = 465
 	SYS_REMOVEXATTRAT           = 466
+	SYS_OPEN_TREE_ATTR          = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm.go
@@ -426,4 +426,5 @@ const (
 	SYS_GETXATTRAT                   = 464
 	SYS_LISTXATTRAT                  = 465
 	SYS_REMOVEXATTRAT                = 466
+	SYS_OPEN_TREE_ATTR               = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_arm64.go
@@ -329,4 +329,5 @@ const (
 	SYS_GETXATTRAT              = 464
 	SYS_LISTXATTRAT             = 465
 	SYS_REMOVEXATTRAT           = 466
+	SYS_OPEN_TREE_ATTR          = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_loong64.go
@@ -325,4 +325,5 @@ const (
 	SYS_GETXATTRAT              = 464
 	SYS_LISTXATTRAT             = 465
 	SYS_REMOVEXATTRAT           = 466
+	SYS_OPEN_TREE_ATTR          = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips.go
@@ -446,4 +446,5 @@ const (
 	SYS_GETXATTRAT                   = 4464
 	SYS_LISTXATTRAT                  = 4465
 	SYS_REMOVEXATTRAT                = 4466
+	SYS_OPEN_TREE_ATTR               = 4467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64.go
@@ -376,4 +376,5 @@ const (
 	SYS_GETXATTRAT              = 5464
 	SYS_LISTXATTRAT             = 5465
 	SYS_REMOVEXATTRAT           = 5466
+	SYS_OPEN_TREE_ATTR          = 5467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mips64le.go
@@ -376,4 +376,5 @@ const (
 	SYS_GETXATTRAT              = 5464
 	SYS_LISTXATTRAT             = 5465
 	SYS_REMOVEXATTRAT           = 5466
+	SYS_OPEN_TREE_ATTR          = 5467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_mipsle.go
@@ -446,4 +446,5 @@ const (
 	SYS_GETXATTRAT                   = 4464
 	SYS_LISTXATTRAT                  = 4465
 	SYS_REMOVEXATTRAT                = 4466
+	SYS_OPEN_TREE_ATTR               = 4467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc.go
@@ -453,4 +453,5 @@ const (
 	SYS_GETXATTRAT                   = 464
 	SYS_LISTXATTRAT                  = 465
 	SYS_REMOVEXATTRAT                = 466
+	SYS_OPEN_TREE_ATTR               = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64.go
@@ -425,4 +425,5 @@ const (
 	SYS_GETXATTRAT              = 464
 	SYS_LISTXATTRAT             = 465
 	SYS_REMOVEXATTRAT           = 466
+	SYS_OPEN_TREE_ATTR          = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_ppc64le.go
@@ -425,4 +425,5 @@ const (
 	SYS_GETXATTRAT              = 464
 	SYS_LISTXATTRAT             = 465
 	SYS_REMOVEXATTRAT           = 466
+	SYS_OPEN_TREE_ATTR          = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_riscv64.go
@@ -330,4 +330,5 @@ const (
 	SYS_GETXATTRAT              = 464
 	SYS_LISTXATTRAT             = 465
 	SYS_REMOVEXATTRAT           = 466
+	SYS_OPEN_TREE_ATTR          = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_s390x.go
@@ -391,4 +391,5 @@ const (
 	SYS_GETXATTRAT              = 464
 	SYS_LISTXATTRAT             = 465
 	SYS_REMOVEXATTRAT           = 466
+	SYS_OPEN_TREE_ATTR          = 467
 )

--- a/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
+++ b/vendor/golang.org/x/sys/unix/zsysnum_linux_sparc64.go
@@ -404,4 +404,5 @@ const (
 	SYS_GETXATTRAT              = 464
 	SYS_LISTXATTRAT             = 465
 	SYS_REMOVEXATTRAT           = 466
+	SYS_OPEN_TREE_ATTR          = 467
 )

--- a/vendor/golang.org/x/sys/unix/ztypes_linux.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux.go
@@ -115,7 +115,9 @@ type Statx_t struct {
 	Atomic_write_unit_max     uint32
 	Atomic_write_segments_max uint32
 	Dio_read_offset_align     uint32
-	_                         [9]uint64
+	Atomic_write_unit_max_opt uint32
+	_                         [1]uint32
+	_                         [8]uint64
 }
 
 type Fsid struct {
@@ -199,7 +201,8 @@ type FscryptAddKeyArg struct {
 	Key_spec FscryptKeySpecifier
 	Raw_size uint32
 	Key_id   uint32
-	_        [8]uint32
+	Flags    uint32
+	_        [7]uint32
 }
 
 type FscryptRemoveKeyArg struct {
@@ -2317,6 +2320,11 @@ const (
 	NFT_CT_AVGPKT                     = 0x10
 	NFT_CT_ZONE                       = 0x11
 	NFT_CT_EVENTMASK                  = 0x12
+	NFT_CT_SRC_IP                     = 0x13
+	NFT_CT_DST_IP                     = 0x14
+	NFT_CT_SRC_IP6                    = 0x15
+	NFT_CT_DST_IP6                    = 0x16
+	NFT_CT_ID                         = 0x17
 	NFTA_CT_UNSPEC                    = 0x0
 	NFTA_CT_DREG                      = 0x1
 	NFTA_CT_KEY                       = 0x2
@@ -2597,8 +2605,8 @@ const (
 	SOF_TIMESTAMPING_BIND_PHC     = 0x8000
 	SOF_TIMESTAMPING_OPT_ID_TCP   = 0x10000
 
-	SOF_TIMESTAMPING_LAST = 0x20000
-	SOF_TIMESTAMPING_MASK = 0x3ffff
+	SOF_TIMESTAMPING_LAST = 0x40000
+	SOF_TIMESTAMPING_MASK = 0x7ffff
 
 	SCM_TSTAMP_SND   = 0x0
 	SCM_TSTAMP_SCHED = 0x1
@@ -4044,7 +4052,7 @@ const (
 	ETHTOOL_A_TSINFO_PHC_INDEX                = 0x5
 	ETHTOOL_A_TSINFO_STATS                    = 0x6
 	ETHTOOL_A_TSINFO_HWTSTAMP_PROVIDER        = 0x7
-	ETHTOOL_A_TSINFO_MAX                      = 0x7
+	ETHTOOL_A_TSINFO_MAX                      = 0x9
 	ETHTOOL_A_CABLE_TEST_UNSPEC               = 0x0
 	ETHTOOL_A_CABLE_TEST_HEADER               = 0x1
 	ETHTOOL_A_CABLE_TEST_MAX                  = 0x1
@@ -4128,6 +4136,19 @@ const (
 	ETHTOOL_A_TUNNEL_INFO_HEADER              = 0x1
 	ETHTOOL_A_TUNNEL_INFO_UDP_PORTS           = 0x2
 	ETHTOOL_A_TUNNEL_INFO_MAX                 = 0x2
+)
+
+const (
+	TCP_V4_FLOW    = 0x1
+	UDP_V4_FLOW    = 0x2
+	TCP_V6_FLOW    = 0x5
+	UDP_V6_FLOW    = 0x6
+	ESP_V4_FLOW    = 0xa
+	ESP_V6_FLOW    = 0xc
+	IP_USER_FLOW   = 0xd
+	IPV6_USER_FLOW = 0xe
+	IPV6_FLOW      = 0x11
+	ETHER_FLOW     = 0x12
 )
 
 const SPEED_UNKNOWN = -0x1
@@ -4780,7 +4801,7 @@ const (
 	NL80211_ATTR_MAC_HINT                                   = 0xc8
 	NL80211_ATTR_MAC_MASK                                   = 0xd7
 	NL80211_ATTR_MAX_AP_ASSOC_STA                           = 0xca
-	NL80211_ATTR_MAX                                        = 0x150
+	NL80211_ATTR_MAX                                        = 0x151
 	NL80211_ATTR_MAX_CRIT_PROT_DURATION                     = 0xb4
 	NL80211_ATTR_MAX_CSA_COUNTERS                           = 0xce
 	NL80211_ATTR_MAX_HW_TIMESTAMP_PEERS                     = 0x143
@@ -5414,7 +5435,7 @@ const (
 	NL80211_FREQUENCY_ATTR_GO_CONCURRENT                    = 0xf
 	NL80211_FREQUENCY_ATTR_INDOOR_ONLY                      = 0xe
 	NL80211_FREQUENCY_ATTR_IR_CONCURRENT                    = 0xf
-	NL80211_FREQUENCY_ATTR_MAX                              = 0x21
+	NL80211_FREQUENCY_ATTR_MAX                              = 0x22
 	NL80211_FREQUENCY_ATTR_MAX_TX_POWER                     = 0x6
 	NL80211_FREQUENCY_ATTR_NO_10MHZ                         = 0x11
 	NL80211_FREQUENCY_ATTR_NO_160MHZ                        = 0xc
@@ -5530,7 +5551,7 @@ const (
 	NL80211_MAX_SUPP_SELECTORS                              = 0x80
 	NL80211_MBSSID_CONFIG_ATTR_EMA                          = 0x5
 	NL80211_MBSSID_CONFIG_ATTR_INDEX                        = 0x3
-	NL80211_MBSSID_CONFIG_ATTR_MAX                          = 0x5
+	NL80211_MBSSID_CONFIG_ATTR_MAX                          = 0x6
 	NL80211_MBSSID_CONFIG_ATTR_MAX_EMA_PROFILE_PERIODICITY  = 0x2
 	NL80211_MBSSID_CONFIG_ATTR_MAX_INTERFACES               = 0x1
 	NL80211_MBSSID_CONFIG_ATTR_TX_IFINDEX                   = 0x4

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
@@ -282,19 +282,13 @@ type Taskstats struct {
 	Ac_exitcode               uint32
 	Ac_flag                   uint8
 	Ac_nice                   uint8
-	_                         [4]byte
+	_                         [6]byte
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -330,17 +324,11 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	_                         [4]byte
 	Ac_tgetime                uint64
@@ -348,10 +336,22 @@ type Taskstats struct {
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
@@ -300,16 +300,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -344,27 +338,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
@@ -91,7 +91,7 @@ type Stat_t struct {
 	Gid     uint32
 	Rdev    uint64
 	_       uint16
-	_       [4]byte
+	_       [6]byte
 	Size    int64
 	Blksize int32
 	_       [4]byte
@@ -273,19 +273,13 @@ type Taskstats struct {
 	Ac_exitcode               uint32
 	Ac_flag                   uint8
 	Ac_nice                   uint8
-	_                         [4]byte
+	_                         [6]byte
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]uint8
@@ -321,17 +315,11 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	_                         [4]byte
 	Ac_tgetime                uint64
@@ -339,10 +327,22 @@ type Taskstats struct {
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
@@ -279,16 +279,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -323,27 +317,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_loong64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_loong64.go
@@ -280,16 +280,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -324,27 +318,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
@@ -278,19 +278,13 @@ type Taskstats struct {
 	Ac_exitcode               uint32
 	Ac_flag                   uint8
 	Ac_nice                   uint8
-	_                         [4]byte
+	_                         [6]byte
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -326,17 +320,11 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	_                         [4]byte
 	Ac_tgetime                uint64
@@ -344,10 +332,22 @@ type Taskstats struct {
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
@@ -282,16 +282,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -326,27 +320,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
@@ -282,16 +282,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -326,27 +320,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
@@ -278,19 +278,13 @@ type Taskstats struct {
 	Ac_exitcode               uint32
 	Ac_flag                   uint8
 	Ac_nice                   uint8
-	_                         [4]byte
+	_                         [6]byte
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -326,17 +320,11 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	_                         [4]byte
 	Ac_tgetime                uint64
@@ -344,10 +332,22 @@ type Taskstats struct {
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_ppc.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_ppc.go
@@ -90,7 +90,7 @@ type Stat_t struct {
 	Gid     uint32
 	Rdev    uint64
 	_       uint16
-	_       [4]byte
+	_       [6]byte
 	Size    int64
 	Blksize int32
 	_       [4]byte
@@ -285,19 +285,13 @@ type Taskstats struct {
 	Ac_exitcode               uint32
 	Ac_flag                   uint8
 	Ac_nice                   uint8
-	_                         [4]byte
+	_                         [6]byte
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]uint8
@@ -333,17 +327,11 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	_                         [4]byte
 	Ac_tgetime                uint64
@@ -351,10 +339,22 @@ type Taskstats struct {
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
@@ -289,16 +289,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]uint8
@@ -333,27 +327,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
@@ -289,16 +289,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]uint8
@@ -333,27 +327,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
@@ -307,16 +307,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]uint8
@@ -351,27 +345,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
@@ -302,16 +302,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -346,27 +340,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
@@ -284,16 +284,10 @@ type Taskstats struct {
 	Ac_nice                   uint8
 	Cpu_count                 uint64
 	Cpu_delay_total           uint64
-	Cpu_delay_max             uint64
-	Cpu_delay_min             uint64
 	Blkio_count               uint64
 	Blkio_delay_total         uint64
-	Blkio_delay_max           uint64
-	Blkio_delay_min           uint64
 	Swapin_count              uint64
 	Swapin_delay_total        uint64
-	Swapin_delay_max          uint64
-	Swapin_delay_min          uint64
 	Cpu_run_real_total        uint64
 	Cpu_run_virtual_total     uint64
 	Ac_comm                   [32]int8
@@ -328,27 +322,33 @@ type Taskstats struct {
 	Cpu_scaled_run_real_total uint64
 	Freepages_count           uint64
 	Freepages_delay_total     uint64
-	Freepages_delay_max       uint64
-	Freepages_delay_min       uint64
 	Thrashing_count           uint64
 	Thrashing_delay_total     uint64
-	Thrashing_delay_max       uint64
-	Thrashing_delay_min       uint64
 	Ac_btime64                uint64
 	Compact_count             uint64
 	Compact_delay_total       uint64
-	Compact_delay_max         uint64
-	Compact_delay_min         uint64
 	Ac_tgid                   uint32
 	Ac_tgetime                uint64
 	Ac_exe_dev                uint64
 	Ac_exe_inode              uint64
 	Wpcopy_count              uint64
 	Wpcopy_delay_total        uint64
-	Wpcopy_delay_max          uint64
-	Wpcopy_delay_min          uint64
 	Irq_count                 uint64
 	Irq_delay_total           uint64
+	Cpu_delay_max             uint64
+	Cpu_delay_min             uint64
+	Blkio_delay_max           uint64
+	Blkio_delay_min           uint64
+	Swapin_delay_max          uint64
+	Swapin_delay_min          uint64
+	Freepages_delay_max       uint64
+	Freepages_delay_min       uint64
+	Thrashing_delay_max       uint64
+	Thrashing_delay_min       uint64
+	Compact_delay_max         uint64
+	Compact_delay_min         uint64
+	Wpcopy_delay_max          uint64
+	Wpcopy_delay_min          uint64
 	Irq_delay_max             uint64
 	Irq_delay_min             uint64
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -422,7 +422,7 @@ github.com/loft-sh/go-github-selfupdate/selfupdate
 # github.com/loft-sh/loft-util v0.0.9-alpha
 ## explicit; go 1.19
 github.com/loft-sh/loft-util/pkg/command
-# github.com/loft-sh/notify v0.0.0-20210827094439-0720dcc7feee
+# github.com/loft-sh/notify v0.0.0-20250811133046-d79ab32e79b2
 ## explicit; go 1.11
 github.com/loft-sh/notify
 # github.com/loft-sh/programming-language-detection v0.0.5
@@ -826,7 +826,7 @@ golang.org/x/oauth2/internal
 # golang.org/x/sync v0.16.0
 ## explicit; go 1.23.0
 golang.org/x/sync/errgroup
-# golang.org/x/sys v0.34.0
+# golang.org/x/sys v0.35.0
 ## explicit; go 1.23.0
 golang.org/x/sys/cpu
 golang.org/x/sys/plan9


### PR DESCRIPTION
Updates notify dependency that was using deprecated FSEventStreamScheduleWithRunLoop

**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #DSP-137

