### PR TITLE
feat(imports): add mergeStrategy field to support deep merge

### DIFF
--- a/devspace-schema.json
+++ b/devspace-schema.json
@@ -2021,6 +2021,14 @@
           ],
           "description": "Enabled specifies if the given import should be enabled"
         },
+        "mergeStrategy": {
+          "type": "string",
+          "enum": [
+            "shallowMerge",
+            "deepMerge"
+          ],
+          "description": "MergeStrategy specifies how the imported config should be merged (e.g. shallowMerge or deepMerge)"
+        },
         "path": {
           "type": "string",
           "description": "Path is the local path where DevSpace can find the artifact.\nThis option is mutually exclusive with the git option.",

--- a/docs/schemas/config-openapi.json
+++ b/docs/schemas/config-openapi.json
@@ -1045,6 +1045,14 @@
                 "type": "boolean",
                 "description": "Enabled specifies if the given import should be enabled"
               },
+              "mergeStrategy": {
+                "type": "string",
+                "enum": [
+                  "shallowMerge",
+                  "deepMerge"
+                ],
+                "description": "MergeStrategy specifies how the imported config should be merged (e.g. shallowMerge or deepMerge)"
+              },
               "path": {
                 "type": "string",
                 "description": "Path is the local path where DevSpace can find the artifact.\nThis option is mutually exclusive with the git option.",

--- a/pkg/devspace/config/loader/imports.go
+++ b/pkg/devspace/config/loader/imports.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader/variable"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions"
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/util"
 	dependencyutil "github.com/loft-sh/devspace/pkg/devspace/dependency/util"
 	"github.com/loft-sh/devspace/pkg/util/log"
@@ -118,7 +119,15 @@ func ResolveImports(ctx context.Context, resolver variable.Resolver, basePath st
 			if mergedMap[section] == nil {
 				mergedMap[section] = map[string]interface{}{}
 			}
-			deepMerge(mergedMap[section].(map[string]interface{}), sectionMap)
+
+			switch i.MergeStrategy {
+			case latest.MergeStrategyDeep:
+				deepMerge(mergedMap[section].(map[string]interface{}), sectionMap)
+			case "", latest.MergeStrategyShallow:
+				shallowMerge(mergedMap[section].(map[string]interface{}), sectionMap)
+			default:
+				return nil, fmt.Errorf("invalid mergeStrategy %q in import %s", i.MergeStrategy, configPath)
+			}
 		}
 
 		// resolve the import imports
@@ -171,5 +180,15 @@ func deepMerge(dst, src map[string]interface{}) {
 		}
 
 		// For other types (arrays, scalars), dst takes precedence (no action needed)
+	}
+}
+
+// shallowMerge merges src into dst only at the top level.
+// Existing keys in dst take precedence.
+func shallowMerge(dst, src map[string]interface{}) {
+	for key, value := range src {
+		if _, ok := dst[key]; !ok {
+			dst[key] = value
+		}
 	}
 }

--- a/pkg/devspace/config/loader/loader_test.go
+++ b/pkg/devspace/config/loader/loader_test.go
@@ -1988,7 +1988,8 @@ func TestImportsDeepMerge(t *testing.T) {
 		name        string
 		catalogYaml string
 		mainYaml    string
-		verify      func(t *testing.T, dev map[string]*latest.DevPod)
+		expectedErr string
+		verify      func(t *testing.T, config *latest.Config)
 	}{
 		{
 			name: "Catalog provides base config, project adds minimal customization",
@@ -2015,12 +2016,14 @@ version: v2beta1
 name: my-project
 imports:
   - path: catalog.yaml
+    mergeStrategy: deepMerge
 dev:
   api:
     labelSelector:
       app.kubernetes.io/name: my-app
 `,
-			verify: func(t *testing.T, dev map[string]*latest.DevPod) {
+			verify: func(t *testing.T, config *latest.Config) {
+				dev := config.Dev
 				assert.Assert(t, dev["api"] != nil, "api dev config should exist")
 
 				// Project customization
@@ -2053,6 +2056,7 @@ version: v2beta1
 name: my-project
 imports:
   - path: catalog.yaml
+    mergeStrategy: deepMerge
 dev:
   api:
     labelSelector:
@@ -2061,7 +2065,8 @@ dev:
     ports:
       - port: "3000:3000"
 `,
-			verify: func(t *testing.T, dev map[string]*latest.DevPod) {
+			verify: func(t *testing.T, config *latest.Config) {
+				dev := config.Dev
 				assert.Assert(t, dev["api"] != nil, "api dev config should exist")
 
 				// Maps are deep merged
@@ -2097,13 +2102,15 @@ version: v2beta1
 name: my-project
 imports:
   - path: catalog.yaml
+    mergeStrategy: deepMerge
 dev:
   api:
     labelSelector:
       app: my-custom-app
       tier: frontend
 `,
-			verify: func(t *testing.T, dev map[string]*latest.DevPod) {
+			verify: func(t *testing.T, config *latest.Config) {
+				dev := config.Dev
 				assert.Assert(t, dev["api"] != nil, "api dev config should exist")
 
 				// Project overrides specific label
@@ -2145,6 +2152,7 @@ version: v2beta1
 name: my-project
 imports:
   - path: catalog.yaml
+    mergeStrategy: deepMerge
 dev:
   api:
     labelSelector:
@@ -2155,7 +2163,8 @@ dev:
       app.kubernetes.io/name: my-worker
       tier: jobs
 `,
-			verify: func(t *testing.T, dev map[string]*latest.DevPod) {
+			verify: func(t *testing.T, config *latest.Config) {
+				dev := config.Dev
 				// Verify api service
 				assert.Assert(t, dev["api"] != nil, "api dev config should exist")
 				assert.Equal(t, dev["api"].LabelSelector["app.kubernetes.io/name"], "my-api", "api labelSelector")
@@ -2202,12 +2211,14 @@ version: v2beta1
 name: my-project
 imports:
   - path: catalog.yaml
+    mergeStrategy: deepMerge
 dev:
   api:
     labelSelector:
       app.kubernetes.io/name: my-minimal-app
 `,
-			verify: func(t *testing.T, dev map[string]*latest.DevPod) {
+			verify: func(t *testing.T, config *latest.Config) {
+				dev := config.Dev
 				assert.Assert(t, dev["api"] != nil, "api dev config should exist")
 
 				// Only labelSelector from project
@@ -2218,6 +2229,185 @@ dev:
 				assert.Equal(t, dev["api"].Command[0], "/bin/bash", "command value")
 				assert.Equal(t, len(dev["api"].Ports), 2, "all ports from catalog")
 				assert.Assert(t, len(dev["api"].Sync) >= 1, "sync config from catalog")
+			},
+		},
+		{
+			name: "Default merge strategy is shallow merge",
+			catalogYaml: `
+version: v2beta1
+name: catalog
+dev:
+  api:
+    labelSelector:
+      app: catalog-app
+      version: v1
+`,
+			mainYaml: `
+version: v2beta1
+name: my-project
+imports:
+  - path: catalog.yaml
+dev:
+  api:
+    labelSelector:
+      app: project-app
+      tier: frontend
+`,
+			verify: func(t *testing.T, config *latest.Config) {
+				dev := config.Dev
+				assert.Assert(t, dev["api"] != nil, "api dev config should exist")
+
+				// Maps are shallow merged
+				assert.Equal(t, dev["api"].LabelSelector["app"], "project-app", "project overrides 'app' in map")
+				assert.Equal(t, dev["api"].LabelSelector["tier"], "frontend", "project adds 'tier' in map")
+				assert.Equal(t, dev["api"].LabelSelector["version"], "", "catalog 'version' is NOT preserved in map because of shallow merge")
+			},
+		},
+		{
+			name: "Explicit shallowMerge strategy",
+			catalogYaml: `
+version: v2beta1
+name: catalog
+dev:
+  api:
+    labelSelector:
+      app: catalog-app
+      version: v1
+`,
+			mainYaml: `
+version: v2beta1
+name: my-project
+imports:
+  - path: catalog.yaml
+    mergeStrategy: shallowMerge
+dev:
+  api:
+    labelSelector:
+      app: project-app
+      tier: frontend
+`,
+			verify: func(t *testing.T, config *latest.Config) {
+				dev := config.Dev
+				assert.Assert(t, dev["api"] != nil, "api dev config should exist")
+
+				// Maps are shallow merged
+				assert.Equal(t, dev["api"].LabelSelector["app"], "project-app", "project overrides 'app' in map")
+				assert.Equal(t, dev["api"].LabelSelector["tier"], "frontend", "project adds 'tier' in map")
+				assert.Equal(t, dev["api"].LabelSelector["version"], "", "catalog 'version' is NOT preserved in map because of shallow merge")
+			},
+		},
+		{
+			name: "mergeStrategy deepMerge on deployments with mutually exclusive fields",
+			catalogYaml: `
+version: v2beta1
+name: catalog
+deployments:
+  my-app:
+    helm:
+      chart:
+        name: my-chart
+`,
+			mainYaml: `
+version: v2beta1
+name: my-project
+imports:
+  - path: catalog.yaml
+    mergeStrategy: deepMerge
+deployments:
+  my-app:
+    kubectl:
+      manifests:
+        - my-manifest.yaml
+`,
+			expectedErr: "deployments[my-app].kubectl and deployments[my-app].helm cannot be used together",
+			verify: func(t *testing.T, config *latest.Config) {
+			},
+		},
+		{
+			name: "mergeStrategy deepMerge on dev with mutually exclusive fields",
+			catalogYaml: `
+version: v2beta1
+name: catalog
+dev:
+  my-app:
+    imageSelector: my-image
+`,
+			mainYaml: `
+version: v2beta1
+name: my-project
+imports:
+  - path: catalog.yaml
+    mergeStrategy: deepMerge
+dev:
+  my-app:
+    labelSelector:
+      app: my-app
+`,
+			expectedErr: "dev.my-app: image selector and label selector cannot be used together",
+			verify: func(t *testing.T, config *latest.Config) {
+			},
+		},
+		{
+			name: "mergeStrategy shallowMerge on dev with mutually exclusive fields (no regression)",
+			catalogYaml: `
+version: v2beta1
+name: catalog
+dev:
+  my-app:
+    imageSelector: my-image
+`,
+			mainYaml: `
+version: v2beta1
+name: my-project
+imports:
+  - path: catalog.yaml
+    mergeStrategy: shallowMerge
+dev:
+  my-app:
+    labelSelector:
+      app: my-app
+`,
+			verify: func(t *testing.T, config *latest.Config) {
+				dev := config.Dev
+				assert.Assert(t, dev["my-app"] != nil, "my-app dev config should exist")
+
+				// Only labelSelector is kept because my-app exists in dst, so src's my-app (imageSelector) is completely ignored
+				assert.Equal(t, dev["my-app"].ImageSelector, "", "imageSelector should NOT exist because of shallow merge")
+				assert.Equal(t, dev["my-app"].LabelSelector["app"], "my-app", "labelSelector should exist from project")
+			},
+		},
+		{
+			name: "mergeStrategy shallowMerge on deployments with mutually exclusive fields (no regression)",
+			catalogYaml: `
+version: v2beta1
+name: catalog
+deployments:
+  my-app:
+    helm:
+      chart:
+        name: my-chart
+`,
+			mainYaml: `
+version: v2beta1
+name: my-project
+imports:
+  - path: catalog.yaml
+    mergeStrategy: shallowMerge
+deployments:
+  my-app:
+    kubectl:
+      manifests:
+        - my-manifest.yaml
+`,
+			verify: func(t *testing.T, config *latest.Config) {
+				deps := config.Deployments
+				assert.Assert(t, deps["my-app"] != nil, "my-app deployment should exist")
+
+				// Only kubectl is kept because my-app exists in dst, so src's my-app (helm) is completely ignored
+				assert.Assert(t, deps["my-app"].Helm == nil, "helm should NOT exist because of shallow merge")
+				assert.Assert(t, deps["my-app"].Kubectl != nil, "kubectl should exist from project")
+				assert.Equal(t, len(deps["my-app"].Kubectl.Manifests), 1, "kubectl manifests should have 1 item")
+				assert.Equal(t, deps["my-app"].Kubectl.Manifests[0], "my-manifest.yaml", "kubectl manifest should be my-manifest.yaml")
 			},
 		},
 	}
@@ -2237,10 +2427,128 @@ dev:
 			assert.NilError(t, err, "Error creating config loader")
 
 			config, err := loader.Load(context.TODO(), nil, &ConfigOptions{Dry: true}, log.Discard)
+			if tc.expectedErr != "" {
+				assert.ErrorContains(t, err, tc.expectedErr, "Error loading config in test case %s", tc.name)
+				return
+			}
 			assert.NilError(t, err, "Error loading config in test case %s", tc.name)
 
 			// Verify using custom verification function
-			tc.verify(t, config.Config().Dev)
+			tc.verify(t, config.Config())
+		})
+	}
+}
+
+func TestDeepMerge(t *testing.T) {
+	testCases := []struct {
+		name     string
+		dst      map[string]interface{}
+		src      map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "Empty src map",
+			dst:      map[string]interface{}{"a": 1},
+			src:      map[string]interface{}{},
+			expected: map[string]interface{}{"a": 1},
+		},
+		{
+			name:     "Empty dst map",
+			dst:      map[string]interface{}{},
+			src:      map[string]interface{}{"a": 1},
+			expected: map[string]interface{}{"a": 1},
+		},
+		{
+			name: "3 levels deep",
+			dst:  map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"c": 1}}},
+			src:  map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"d": 2}}},
+			expected: map[string]interface{}{
+				"a": map[string]interface{}{
+					"b": map[string]interface{}{
+						"c": 1,
+						"d": 2,
+					},
+				},
+			},
+		},
+		{
+			name:     "src has map, dst has scalar for same key",
+			dst:      map[string]interface{}{"a": "string"},
+			src:      map[string]interface{}{"a": map[string]interface{}{"nested": true}},
+			expected: map[string]interface{}{"a": "string"},
+		},
+		{
+			name:     "src has scalar, dst has map for same key",
+			dst:      map[string]interface{}{"a": map[string]interface{}{"nested": true}},
+			src:      map[string]interface{}{"a": "string"},
+			expected: map[string]interface{}{"a": map[string]interface{}{"nested": true}},
+		},
+		{
+			name:     "nil value in src map",
+			dst:      map[string]interface{}{"a": 1},
+			src:      map[string]interface{}{"b": nil},
+			expected: map[string]interface{}{"a": 1},
+		},
+		{
+			name:     "nil value in dst map",
+			dst:      map[string]interface{}{"a": nil},
+			src:      map[string]interface{}{"a": 1},
+			expected: map[string]interface{}{"a": 1},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			deepMerge(tc.dst, tc.src)
+
+			// Simple comparison for the test cases
+			dstYaml, _ := yaml.Marshal(tc.dst)
+			expectedYaml, _ := yaml.Marshal(tc.expected)
+			assert.Equal(t, string(dstYaml), string(expectedYaml), "Unexpected deepMerge result")
+		})
+	}
+}
+
+func TestShallowMerge(t *testing.T) {
+	testCases := []struct {
+		name     string
+		dst      map[string]interface{}
+		src      map[string]interface{}
+		expected map[string]interface{}
+	}{
+		{
+			name:     "Empty src map",
+			dst:      map[string]interface{}{"a": 1},
+			src:      map[string]interface{}{},
+			expected: map[string]interface{}{"a": 1},
+		},
+		{
+			name:     "Empty dst map",
+			dst:      map[string]interface{}{},
+			src:      map[string]interface{}{"a": 1},
+			expected: map[string]interface{}{"a": 1},
+		},
+		{
+			name:     "Key exists in both (dst wins, no deep merge)",
+			dst:      map[string]interface{}{"a": map[string]interface{}{"b": 1}},
+			src:      map[string]interface{}{"a": map[string]interface{}{"c": 2}},
+			expected: map[string]interface{}{"a": map[string]interface{}{"b": 1}}, // "c" is completely ignored
+		},
+		{
+			name:     "Keys only in src are added",
+			dst:      map[string]interface{}{"a": 1},
+			src:      map[string]interface{}{"b": 2},
+			expected: map[string]interface{}{"a": 1, "b": 2},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			shallowMerge(tc.dst, tc.src)
+
+			dstYaml, _ := yaml.Marshal(tc.dst)
+			expectedYaml, _ := yaml.Marshal(tc.expected)
+			assert.Equal(t, string(dstYaml), string(expectedYaml), "Unexpected shallowMerge result")
 		})
 	}
 }

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -129,9 +129,22 @@ type Import struct {
 	// Enabled specifies if the given import should be enabled
 	Enabled *bool `yaml:"enabled,omitempty" json:"enabled,omitempty" jsonschema:"required"`
 
+	// MergeStrategy specifies how the imported config should be merged (e.g. shallowMerge or deepMerge)
+	MergeStrategy string `yaml:"mergeStrategy,omitempty" json:"mergeStrategy,omitempty" jsonschema:"enum=shallowMerge,enum=deepMerge"`
+
 	// SourceConfig defines the source for this import
 	SourceConfig `yaml:",inline" json:",inline"`
 }
+
+const (
+	// MergeStrategyShallow performs a shallow merge where only top-level keys
+	// within each config section are merged. This is the default behavior.
+	MergeStrategyShallow = "shallowMerge"
+
+	// MergeStrategyDeep performs a recursive deep merge where nested maps are
+	// merged key by key. Arrays and scalars in the local config take precedence.
+	MergeStrategyDeep = "deepMerge"
+)
 
 // Pipeline defines what DevSpace should do. A pipeline consists of one or more
 // jobs that are run in parallel and can depend on each other. Each job consists


### PR DESCRIPTION
**What issue type does this pull request address?**

/kind feature

**What does this pull request do? Which issues does it resolve?**

Adds an opt-in `mergeStrategy` field on imports to support recursive deep merge of config sections.

**Problem:**
When importing a config (e.g., from a git catalog), the current implementation only does a shallow merge at the first level. If both the imported config and the local config define the same section (like `dev.api`), nested maps are completely replaced instead of being merged.

Example:
```yaml
# Catalog
dev:
  api:
    labelSelector:
      app: catalog-app
      version: v1
    command: ["/bin/bash"]

# Local config
dev:
  api:
    labelSelector:
      app: my-app
```

**Before:** Local `dev.api` replaces catalog entirely, loses `version: v1`, `command`, etc.
**After (with `mergeStrategy: deepMerge`):** Maps are deep merged, keeps both `app: my-app` and `version: v1`

**Solution:**
A new `mergeStrategy` field on each import entry, with two values:

- `shallowMerge` (default, current behavior): only top-level keys within each section are merged. Existing keys in the local config take precedence entirely.
- `deepMerge` (opt-in): maps are merged recursively. Arrays and scalars in the local config still take precedence.

```yaml
imports:
  - git: https://github.com/org/catalog.git
    subPath: devspace.yaml
    mergeStrategy: deepMerge
```

**Merge rules when `deepMerge` is enabled:**
| Type | Behavior |
|---|---|
| Maps | Recursively merged (local keys override on conflict, catalog keys preserved otherwise) |
| Arrays | Local replaces catalog entirely |
| Scalars | Local overrides catalog |

This enables the common use case where organizations maintain a shared catalog in git, and projects only need to override specific values (like `labelSelector`) while inheriting everything else (ports, sync config, commands, etc.).

**Please provide a short message that should be published in the DevSpace release notes**

Imports now support a `mergeStrategy` field. Set `mergeStrategy: deepMerge` on an import to enable recursive map merging, allowing projects to inherit shared catalog configs while only overriding specific nested values. Default behavior (`shallowMerge`) is unchanged.

**What else do we need to know?**

- **Fully backward compatible**: default is `shallowMerge`, which preserves the existing behavior exactly. No existing config is affected.
- **Mutually exclusive fields are safe**: since deep merge is opt-in, users who don't use it are not affected. When `deepMerge` combines fields that shouldn't coexist, the existing validations in `validate.go` catch it properly. This is tested explicitly:
  - `deployments`: `helm` + `kubectl` on the same deployment triggers `"deployments[x].kubectl and deployments[x].helm cannot be used together"`
  - `dev`: `imageSelector` + `labelSelector` on the same dev pod triggers `"dev.x: image selector and label selector cannot be used together"`
  - Both cases are also tested with `shallowMerge` to prove no regression (the conflicting field from the catalog is simply ignored)
- Comprehensive test coverage:
  - 11 integration tests via `TestImportsDeepMerge` (deep merge scenarios, default shallow, explicit shallow, mutually exclusive field validation in both `deployments` and `dev` sections)
  - 7 unit tests for `deepMerge` (edge cases: empty maps, 3-level nesting, type mismatches, nil values)
  - 4 unit tests for `shallowMerge`
- Schema files (`devspace-schema.json`, `config-openapi.json`) regenerated, IDE autocomplete works out of the box
- All existing tests pass