### PR TITLE
feat(download): add download env var

### DIFF
--- a/pkg/devspace/server/download.go
+++ b/pkg/devspace/server/download.go
@@ -44,7 +44,7 @@ func downloadUI() (string, error) {
 		downloadDir, _ = homedir.Dir()
 	}
 	// Check if ui was already downloaded / extracted
-	uiFolder := filepath.Join(downloadDir, constants.DefaultHomeDevSpaceFolder, UITempFolder)
+	uiFolder := filepath.Join(downloadDir, constants.DefaultHomeDevSpaceFolder, UITempFolder, version)
 
 	// Download / extract if necessary
 	err := downloadUITar(uiFolder, version)

--- a/pkg/devspace/server/download.go
+++ b/pkg/devspace/server/download.go
@@ -43,8 +43,10 @@ func downloadUI() (string, error) {
 	if downloadDir == "" {
 		downloadDir, _ = homedir.Dir()
 	}
+	// Check if ui was already downloaded / extracted
 	uiFolder := filepath.Join(downloadDir, constants.DefaultHomeDevSpaceFolder, UITempFolder)
 
+	// Download / extract if necessary
 	err := downloadUITar(uiFolder, version)
 	if err != nil {
 		return "", errors.Wrap(err, "download ui tar ball")

--- a/pkg/devspace/server/download.go
+++ b/pkg/devspace/server/download.go
@@ -13,12 +13,12 @@ import (
 	"time"
 
 	"github.com/loft-sh/devspace/assets"
+	"github.com/mitchellh/go-homedir"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/constants"
 	"github.com/loft-sh/devspace/pkg/devspace/upgrade"
 	"github.com/loft-sh/devspace/pkg/util/git"
 
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 )
 
@@ -38,17 +38,17 @@ func downloadUI() (string, error) {
 		version = "latest"
 	}
 
-	homedir, _ := homedir.Dir()
+	downloadDir := os.Getenv("DEVSPACE_HOME")
 
-	// Check if ui was already downloaded / extracted
-	uiFolder := filepath.Join(homedir, constants.DefaultHomeDevSpaceFolder, UITempFolder, version)
+	if downloadDir == "" {
+		downloadDir, _ = homedir.Dir()
+	}
+	uiFolder := filepath.Join(downloadDir, constants.DefaultHomeDevSpaceFolder, UITempFolder)
 
-	// Download / extract if necessary
 	err := downloadUITar(uiFolder, version)
 	if err != nil {
 		return "", errors.Wrap(err, "download ui tar ball")
 	}
-
 	return uiFolder, nil
 }
 


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind enhancement
/kind feature

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #3106


**Please provide a short message that should be published in the DevSpace release notes**
Added the option to designate a specific download directory/folder with an environment variable

**What else do we need to know?** 
There seems to be an issue (unrelated to my changes - tested with and without them as well as directly from main) with testing the helm download (coverage - unit test):

```bash
[...]
--- FAIL: TestHelmDownload (0.51s)
    engine_test.go:135: assertion failed: expression is false: strings.Contains(stdout1.String(), `Version:"v3`)
FAIL
coverage: 65.4% of statements
FAIL    github.com/loft-sh/devspace/pkg/devspace/pipeline/engine        1.076s
FAIL
        github.com/loft-sh/devspace/pkg/devspace/pipeline/engine/basichandler           coverage: 0.0% of statements
[...]
```