### PR TITLE
feature(sync): Implement syncing across replicas in a Deployment,ReplicaSet,StatefulSet

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -38,6 +38,7 @@ type SyncCmd struct {
 	ImageSelector string
 	Container     string
 	Pod           string
+	SyncReplicas  bool
 	Pick          bool
 	Wait          bool
 	Polling       bool
@@ -85,6 +86,7 @@ devspace sync --path=.:/app --pod=my-pod --container=my-container
 
 	syncCmd.Flags().StringVarP(&cmd.Container, "container", "c", "", "Container name within pod where to sync to")
 	syncCmd.Flags().StringVar(&cmd.Pod, "pod", "", "Pod to sync to")
+	syncCmd.Flags().BoolVar(&cmd.SyncReplicas, "sync-replicas", false, "Sync all replicas in the selected deployment")
 	syncCmd.Flags().StringVarP(&cmd.LabelSelector, "label-selector", "l", "", "Comma separated key=value selector list (e.g. release=test)")
 	syncCmd.Flags().StringVar(&cmd.ImageSelector, "image-selector", "", "The image to search a pod for (e.g. nginx, nginx:latest, ${runtime.images.app}, nginx:${runtime.images.app.tag})")
 	syncCmd.Flags().BoolVar(&cmd.Pick, "pick", true, "Select a pod")
@@ -270,6 +272,12 @@ func (cmd *SyncCmd) Run(f factory.Factory) error {
 	if err != nil {
 		return errors.Wrap(err, "apply flags to sync config")
 	}
+	if syncConfig.syncConfig.SyncReplicas {
+		cmd.SyncReplicas = true
+	}
+	if cmd.SyncReplicas {
+		options = options.WithPick(false)
+	}
 
 	// Start sync
 	options = options.WithSkipInitContainers(true)
@@ -312,6 +320,9 @@ func (cmd *SyncCmd) applyFlagsToSyncConfig(syncConfig *latest.SyncConfig, option
 	}
 	if cmd.DownloadOnly {
 		syncConfig.DisableUpload = cmd.DownloadOnly
+	}
+	if cmd.SyncReplicas {
+		syncConfig.SyncReplicas = true
 	}
 
 	// if selection is specified through flags, we don't want to use the loaded

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -11,6 +11,7 @@ import (
 	"github.com/loft-sh/devspace/e2e/kube"
 	"github.com/onsi/gomega"
 	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -167,6 +168,52 @@ func ExpectRemoteContainerFileContents(labelSelector, container string, namespac
 		return out == contents, nil
 	})
 	ExpectNoErrorWithOffset(1, err)
+}
+
+func ExpectRemoteFileContentsOnAllPods(labelSelector, containerName, namespace, filePath, contents string, wantCount int) {
+	kubeClient, err := kube.NewKubeHelper()
+	ExpectNoErrorWithOffset(1, err)
+
+	want := strings.TrimSpace(contents)
+	err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*3, true, func(ctx context.Context) (done bool, err error) {
+		pods, err := kubeClient.RawClient().CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
+		if err != nil {
+			return false, nil
+		}
+		readyPods := make([]corev1.Pod, 0, len(pods.Items))
+		for _, p := range pods.Items {
+			if p.Status.Phase != corev1.PodRunning {
+				continue
+			}
+			if !podContainerReady(&p, containerName) {
+				continue
+			}
+			readyPods = append(readyPods, p)
+		}
+		if len(readyPods) < wantCount {
+			return false, nil
+		}
+		for i := range readyPods {
+			out, err := kubeClient.ExecInPod(ctx, &readyPods[i], containerName, []string{"cat", filePath})
+			if err != nil {
+				return false, nil
+			}
+			if strings.TrimSpace(out) != want {
+				return false, nil
+			}
+		}
+		return true, nil
+	})
+	ExpectNoErrorWithOffset(1, err)
+}
+
+func podContainerReady(pod *corev1.Pod, containerName string) bool {
+	for _, cs := range pod.Status.ContainerStatuses {
+		if cs.Name == containerName {
+			return cs.Ready
+		}
+	}
+	return false
 }
 
 func ExpectLocalFileContentsImmediately(filePath string, contents string) {

--- a/e2e/kube/kube.go
+++ b/e2e/kube/kube.go
@@ -98,3 +98,12 @@ func (k *KubeHelper) DeleteNamespace(name string) error {
 	}
 	return nil
 }
+
+// ExecInPod runs a command in an existing pod container (used when multiple pods match a selector).
+func (k *KubeHelper) ExecInPod(ctx context.Context, pod *corev1.Pod, containerName string, command []string) (string, error) {
+	stdout, stderr, err := k.client.ExecBuffered(ctx, pod, containerName, command, nil)
+	if err != nil {
+		return "", fmt.Errorf("exec error: %v %s", err, string(stderr))
+	}
+	return string(stdout), nil
+}

--- a/e2e/tests/sync/sync.go
+++ b/e2e/tests/sync/sync.go
@@ -846,4 +846,55 @@ var _ = DevSpaceDescribe("sync", func() {
 		// wait for the command to finish
 		waitGroup.Wait()
 	})
+
+	ginkgo.It("should sync to all replicas when syncReplicas is enabled", func() {
+		tempDir, err := framework.CopyToTempDir("tests/sync/testdata/sync-replicas")
+		framework.ExpectNoError(err)
+		defer framework.CleanupTempDir(initialDir, tempDir)
+
+		ns, err := kubeClient.CreateNamespace("sync")
+		framework.ExpectNoError(err)
+		defer func() {
+			err := kubeClient.DeleteNamespace(ns)
+			framework.ExpectNoError(err)
+		}()
+
+		cancelCtx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		devCmd := &cmd.RunPipelineCmd{
+			GlobalFlags: &flags.GlobalFlags{
+				NoWarn:    true,
+				Namespace: ns,
+			},
+			Pipeline: "dev",
+			Ctx:      cancelCtx,
+		}
+
+		waitGroup := sync.WaitGroup{}
+		waitGroup.Add(1)
+		go func() {
+			defer ginkgo.GinkgoRecover()
+			defer waitGroup.Done()
+			err = devCmd.RunDefault(f)
+			framework.ExpectNoError(err)
+		}()
+
+		const (
+			podLabel     = "app.kubernetes.io/name=sync-replicas"
+			container    = "app"
+			replicaCount = 2
+		)
+
+		framework.ExpectRemoteFileContentsOnAllPods(podLabel, container, ns, "/app/file1.txt", "Hello World", replicaCount)
+
+		payload := randutil.GenerateRandomString(5000)
+		err = os.WriteFile(filepath.Join(tempDir, "replica-upload.txt"), []byte(payload), 0666)
+		framework.ExpectNoError(err)
+
+		framework.ExpectRemoteFileContentsOnAllPods(podLabel, container, ns, "/app/replica-upload.txt", payload, replicaCount)
+
+		cancel()
+		waitGroup.Wait()
+	})
 })

--- a/e2e/tests/sync/testdata/sync-replicas/devspace.yaml
+++ b/e2e/tests/sync/testdata/sync-replicas/devspace.yaml
@@ -1,0 +1,19 @@
+version: v2beta1
+vars:
+  IMAGE: alpine:3.20
+deployments:
+  test:
+    kubectl:
+      manifests:
+        - k8s/deployment.yaml
+pipelines:
+  deploy: |-
+    run_dependencies --all
+    create_deployments --all
+dev:
+  test:
+    imageSelector: ${IMAGE}
+    sync:
+      - path: ./:/app
+        waitInitialSync: true
+        syncReplicas: true

--- a/e2e/tests/sync/testdata/sync-replicas/file1.txt
+++ b/e2e/tests/sync/testdata/sync-replicas/file1.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/e2e/tests/sync/testdata/sync-replicas/k8s/deployment.yaml
+++ b/e2e/tests/sync/testdata/sync-replicas/k8s/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sync-replicas
+  labels:
+    app.kubernetes.io/name: sync-replicas
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: sync-replicas
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: sync-replicas
+    spec:
+      containers:
+        - name: app
+          image: alpine:3.20
+          command: ["tail", "-f", "/dev/null"]

--- a/pkg/devspace/config/versions/latest/schema.go
+++ b/pkg/devspace/config/versions/latest/schema.go
@@ -1151,6 +1151,8 @@ type SyncConfig struct {
 	DisableDownload bool `yaml:"disableDownload,omitempty" json:"disableDownload,omitempty" jsonschema_extras:"group=one_direction,group_name=One-Directional Sync"`
 	// DisableUpload will disable uploading completely
 	DisableUpload bool `yaml:"disableUpload,omitempty" json:"disableUpload,omitempty" jsonschema_extras:"group=one_direction"`
+	// SyncReplicas enables sync for all replicas in the selected deployment.
+	SyncReplicas bool `yaml:"syncReplicas,omitempty" json:"syncReplicas,omitempty"`
 
 	// BandwidthLimits can be used to limit the amount of bytes that are transferred by DevSpace with this
 	// sync configuration

--- a/pkg/devspace/services/podreplace/builder.go
+++ b/pkg/devspace/services/podreplace/builder.go
@@ -13,6 +13,7 @@ import (
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
 	"github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
 	"github.com/loft-sh/devspace/pkg/util/hash"
+	"github.com/loft-sh/devspace/pkg/util/ptr"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -156,6 +157,7 @@ func buildDeployment(ctx devspacecontext.Context, name string, target runtime.Ob
 	}
 
 	deployment.Spec.Template = *podTemplate
+	deployment.Spec.Replicas = desiredReplacementReplicas(target, devPod)
 	if deployment.Spec.Selector == nil {
 		deployment.Spec.Selector = &metav1.LabelSelector{}
 	}
@@ -175,6 +177,45 @@ func buildDeployment(ctx devspacecontext.Context, name string, target runtime.Ob
 	}
 
 	return deployment, nil
+}
+
+func desiredReplacementReplicas(target runtime.Object, devPod *latest.DevPod) *int32 {
+	// Preserve historical behavior unless syncReplicas is explicitly enabled.
+	if !hasSyncReplicas(devPod) {
+		return ptr.Int32(1)
+	}
+
+	switch t := target.(type) {
+	case *appsv1.ReplicaSet:
+		if t.Spec.Replicas != nil {
+			return ptr.Int32(*t.Spec.Replicas)
+		}
+	case *appsv1.Deployment:
+		if t.Spec.Replicas != nil {
+			return ptr.Int32(*t.Spec.Replicas)
+		}
+	case *appsv1.StatefulSet:
+		if t.Spec.Replicas != nil {
+			return ptr.Int32(*t.Spec.Replicas)
+		}
+	}
+
+	return ptr.Int32(1)
+}
+
+func hasSyncReplicas(devPod *latest.DevPod) bool {
+	hasSyncReplicas := false
+	loader.EachDevContainer(devPod, func(devContainer *latest.DevContainer) bool {
+		for _, s := range devContainer.Sync {
+			if s.SyncReplicas {
+				hasSyncReplicas = true
+				return false
+			}
+		}
+		return true
+	})
+
+	return hasSyncReplicas
 }
 
 func modifyDevContainer(ctx devspacecontext.Context, devPod *latest.DevPod, devContainer *latest.DevContainer, podTemplate *corev1.PodTemplateSpec) error {

--- a/pkg/devspace/services/podreplace/replace.go
+++ b/pkg/devspace/services/podreplace/replace.go
@@ -158,7 +158,7 @@ func updateNeeded(ctx devspacecontext.Context, deployment *appsv1.Deployment, de
 
 	// update deployment
 	originalDeployment := deployment.DeepCopy()
-	deployment.Spec.Replicas = ptr.Int32(1)
+	deployment.Spec.Replicas = newDeployment.Spec.Replicas
 	deployment.Spec.Selector = newDeployment.Spec.Selector
 	deployment.Spec.Template = newDeployment.Spec.Template
 	deployment.Annotations = newDeployment.Annotations

--- a/pkg/devspace/services/sync/sync.go
+++ b/pkg/devspace/services/sync/sync.go
@@ -3,39 +3,39 @@ package sync
 import (
 	"context"
 	"fmt"
+	"sort"
+	stdsync "sync"
+
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
+	kubeselector "github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
 	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
 	"github.com/loft-sh/devspace/pkg/devspace/sync"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/loft-sh/devspace/pkg/util/tomb"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+type syncTargetSelector struct {
+	selector  targetselector.TargetSelector
+	namespace string
+	pod       string
+	container string
+}
 
 // StartSyncFromCmd starts a new sync from command
 func StartSyncFromCmd(ctx devspacecontext.Context, selector targetselector.TargetSelector, name string, syncConfig *latest.SyncConfig, noWatch bool) error {
 	ctx, parent := ctx.WithNewTomb()
-	options := &Options{
-		Name:           name,
-		SyncConfig:     syncConfig,
-		Selector:       selector,
-		RestartOnError: true,
-		SyncLog:        ctx.Log(),
-
-		Verbose: ctx.Log().GetLevel() == logrus.DebugLevel,
-	}
-
-	// Start the tomb
 	<-parent.NotifyGo(func() error {
-		// this is needed as otherwise the context
-		// is cancelled alongside the tomb
 		parent.Go(func() error {
 			<-ctx.Context().Done()
 			return nil
 		})
-
-		return NewController().Start(ctx, options, parent)
+		return startSync(ctx, name, "", syncConfig, selector, nil, parent)
 	})
 
 	// Handle no watch
@@ -60,6 +60,127 @@ func StartSyncFromCmd(ctx devspacecontext.Context, selector targetselector.Targe
 	}
 }
 
+func buildTargetSelectors(ctx devspacecontext.Context, selector targetselector.TargetSelector, syncConfig *latest.SyncConfig) ([]syncTargetSelector, error) {
+	targets := []syncTargetSelector{{
+		selector: selector,
+	}}
+	if !syncReplicasEnabled(syncConfig) {
+		return targets, nil
+	}
+
+	primary, err := selector.SelectSingleContainer(ctx.Context(), ctx.KubeClient(), ctx.Log())
+	if err != nil {
+		return nil, err
+	}
+	if primary == nil {
+		return nil, fmt.Errorf("couldn't find a pod / container with the configured selector")
+	}
+
+	deploymentName, err := findDeploymentName(ctx.Context(), ctx.KubeClient(), primary.Pod)
+	if err != nil {
+		return nil, err
+	}
+	if deploymentName == "" {
+		return nil, fmt.Errorf("pod %s/%s is not part of a deployment", primary.Pod.Namespace, primary.Pod.Name)
+	}
+
+	deployment, err := ctx.KubeClient().KubeClient().AppsV1().Deployments(primary.Pod.Namespace).Get(ctx.Context(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if deployment.Spec.Selector == nil {
+		return nil, fmt.Errorf("deployment %s/%s has no selector", deployment.Namespace, deployment.Name)
+	}
+	deploymentSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	podList, err := ctx.KubeClient().KubeClient().CoreV1().Pods(primary.Pod.Namespace).List(ctx.Context(), metav1.ListOptions{
+		LabelSelector: deploymentSelector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no pods found in deployment %s/%s", primary.Pod.Namespace, deployment.Name)
+	}
+
+	pods := make([]*kubeselector.SelectedPodContainer, 0, len(podList.Items))
+	for i := range podList.Items {
+		pod := podList.Items[i]
+		podDeploymentName, err := findDeploymentName(ctx.Context(), ctx.KubeClient(), &pod)
+		if err != nil {
+			return nil, err
+		}
+		if podDeploymentName != deploymentName {
+			continue
+		}
+		pods = append(pods, &kubeselector.SelectedPodContainer{
+			Pod:       &pod,
+			Container: primary.Container,
+		})
+	}
+	if len(pods) == 0 {
+		return nil, fmt.Errorf("no pods found in deployment %s/%s", primary.Pod.Namespace, deployment.Name)
+	}
+
+	sort.Slice(pods, func(i, j int) bool {
+		return kubeselector.SortContainersByNewest(pods, i, j)
+	})
+
+	targets = make([]syncTargetSelector, 0, len(pods))
+	for _, container := range pods {
+		targets = append(targets, syncTargetSelector{
+			selector: targetselector.NewTargetSelector(
+				targetselector.NewOptionsFromFlags(container.Container.Name, "", nil, container.Pod.Namespace, container.Pod.Name),
+			),
+			namespace: container.Pod.Namespace,
+			pod:       container.Pod.Name,
+			container: container.Container.Name,
+		})
+	}
+
+	ctx.Log().Infof("syncReplicas enabled: starting %d sync targets for path %s", len(targets), syncConfig.Path)
+	return targets, nil
+}
+
+func findDeploymentName(ctx context.Context, client kubectl.Client, pod *corev1.Pod) (string, error) {
+	for _, ownerRef := range pod.OwnerReferences {
+		if ownerRef.Kind == "Deployment" {
+			return ownerRef.Name, nil
+		}
+		if ownerRef.Kind == "ReplicaSet" {
+			replicaSet, err := client.KubeClient().AppsV1().ReplicaSets(pod.Namespace).Get(ctx, ownerRef.Name, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+
+			for _, rsOwnerRef := range replicaSet.OwnerReferences {
+				if rsOwnerRef.Kind == "Deployment" {
+					return rsOwnerRef.Name, nil
+				}
+			}
+		}
+	}
+
+	return "", nil
+}
+
+func configForTarget(syncConfig *latest.SyncConfig, targetIndex int) *latest.SyncConfig {
+	copied := *syncConfig
+	if targetIndex > 0 {
+		copied.DisableDownload = true
+		copied.OnUpload = nil
+	}
+
+	return &copied
+}
+
+func syncReplicasEnabled(syncConfig *latest.SyncConfig) bool {
+	return syncConfig.SyncReplicas
+}
+
 // StartSync starts the syncing functionality
 func StartSync(ctx devspacecontext.Context, devPod *latest.DevPod, selector targetselector.TargetSelector, parent *tomb.Tomb) (retErr error) {
 	if ctx == nil || ctx.Config() == nil || ctx.Config().Config() == nil {
@@ -73,6 +194,9 @@ func StartSync(ctx devspacecontext.Context, devPod *latest.DevPod, selector targ
 
 		// make sure we add all the sync paths that need to wait for initial start
 		for _, syncConfig := range devContainer.Sync {
+			if syncConfig.SyncReplicas {
+				continue
+			}
 			if syncConfig.StartContainer || (syncConfig.OnUpload != nil && syncConfig.OnUpload.RestartContainer) {
 				starter.Inc()
 			}
@@ -116,24 +240,85 @@ func StartSync(ctx devspacecontext.Context, devPod *latest.DevPod, selector targ
 }
 
 func startSync(ctx devspacecontext.Context, name, arch string, syncConfig *latest.SyncConfig, selector targetselector.TargetSelector, starter sync.DelayedContainerStarter, parent *tomb.Tomb) error {
-	// set options
+	targetSelectors, err := buildTargetSelectors(ctx, selector, syncConfig)
+	if err != nil {
+		return err
+	}
+
+	// Multiple replica targets must not share the dev session tomb: the sync controller
+	// calls parent.Kill on normal completion and errors, which would tear down every
+	// other sync (including other dev pods) mid-flight. Use an isolated tomb per target.
+	if len(targetSelectors) == 1 {
+		return startSyncOneTarget(ctx, name, arch, syncConfig, starter, parent, targetSelectors, 0)
+	}
+
+	var wg stdsync.WaitGroup
+	errs := make([]error, len(targetSelectors))
+	for i := range targetSelectors {
+		wg.Add(1)
+		i := i
+		go func() {
+			defer wg.Done()
+			var subTomb tomb.Tomb
+			errs[i] = startSyncOneTarget(ctx, name, arch, syncConfig, starter, &subTomb, targetSelectors, i)
+		}()
+	}
+	wg.Wait()
+	for _, e := range errs {
+		if e != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+func startSyncOneTarget(
+	ctx devspacecontext.Context,
+	name, arch string,
+	syncConfig *latest.SyncConfig,
+	starter sync.DelayedContainerStarter,
+	syncParent *tomb.Tomb,
+	targetSelectors []syncTargetSelector,
+	i int,
+) error {
+	target := targetSelectors[i]
+	syncConfigForTarget := configForTarget(syncConfig, i)
+	if syncReplicasEnabled(syncConfig) && target.pod != "" && target.container != "" {
+		ctx.Log().Infof(
+			"Sync target %d/%d: %s/%s:%s (disableUpload=%t disableDownload=%t)",
+			i+1,
+			len(targetSelectors),
+			target.namespace,
+			target.pod,
+			target.container,
+			syncConfigForTarget.DisableUpload,
+			syncConfigForTarget.DisableDownload,
+		)
+	}
+
+	effectiveStarter := starter
+	if syncReplicasEnabled(syncConfig) && (syncConfig.StartContainer || (syncConfig.OnUpload != nil && syncConfig.OnUpload.RestartContainer)) {
+		ts := sync.NewDelayedContainerStarter()
+		ts.Inc()
+		effectiveStarter = ts
+	}
+
 	options := &Options{
 		Name:       name,
-		Selector:   selector,
-		SyncConfig: syncConfig,
+		Selector:   target.selector,
+		SyncConfig: syncConfigForTarget,
 		Arch:       arch,
-		Starter:    starter,
+		Starter:    effectiveStarter,
 
 		RestartOnError: true,
 		Verbose:        ctx.Log().GetLevel() == logrus.DebugLevel,
 	}
 
-	// should we print the logs?
-	if syncConfig.PrintLogs || ctx.Log().GetLevel() == logrus.DebugLevel {
+	if syncConfigForTarget.PrintLogs || ctx.Log().GetLevel() == logrus.DebugLevel {
 		options.SyncLog = ctx.Log()
 	} else {
 		options.SyncLog = logpkg.GetDevPodFileLogger(name)
 	}
 
-	return NewController().Start(ctx, options, parent)
+	return NewController().Start(ctx, options, syncParent)
 }

--- a/pkg/devspace/services/sync/sync.go
+++ b/pkg/devspace/services/sync/sync.go
@@ -3,29 +3,18 @@ package sync
 import (
 	"context"
 	"fmt"
-	"sort"
 	stdsync "sync"
 
 	"github.com/loft-sh/devspace/pkg/devspace/config/loader"
 	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
 	devspacecontext "github.com/loft-sh/devspace/pkg/devspace/context"
-	kubeselector "github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
-	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	"github.com/loft-sh/devspace/pkg/devspace/services/sync/synctarget"
 	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
 	"github.com/loft-sh/devspace/pkg/devspace/sync"
 	logpkg "github.com/loft-sh/devspace/pkg/util/log"
 	"github.com/loft-sh/devspace/pkg/util/tomb"
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-type syncTargetSelector struct {
-	selector  targetselector.TargetSelector
-	namespace string
-	pod       string
-	container string
-}
 
 // StartSyncFromCmd starts a new sync from command
 func StartSyncFromCmd(ctx devspacecontext.Context, selector targetselector.TargetSelector, name string, syncConfig *latest.SyncConfig, noWatch bool) error {
@@ -58,127 +47,6 @@ func StartSyncFromCmd(ctx devspacecontext.Context, selector targetselector.Targe
 		_ = parent.Wait()
 		return nil
 	}
-}
-
-func buildTargetSelectors(ctx devspacecontext.Context, selector targetselector.TargetSelector, syncConfig *latest.SyncConfig) ([]syncTargetSelector, error) {
-	targets := []syncTargetSelector{{
-		selector: selector,
-	}}
-	if !syncReplicasEnabled(syncConfig) {
-		return targets, nil
-	}
-
-	primary, err := selector.SelectSingleContainer(ctx.Context(), ctx.KubeClient(), ctx.Log())
-	if err != nil {
-		return nil, err
-	}
-	if primary == nil {
-		return nil, fmt.Errorf("couldn't find a pod / container with the configured selector")
-	}
-
-	deploymentName, err := findDeploymentName(ctx.Context(), ctx.KubeClient(), primary.Pod)
-	if err != nil {
-		return nil, err
-	}
-	if deploymentName == "" {
-		return nil, fmt.Errorf("pod %s/%s is not part of a deployment", primary.Pod.Namespace, primary.Pod.Name)
-	}
-
-	deployment, err := ctx.KubeClient().KubeClient().AppsV1().Deployments(primary.Pod.Namespace).Get(ctx.Context(), deploymentName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	if deployment.Spec.Selector == nil {
-		return nil, fmt.Errorf("deployment %s/%s has no selector", deployment.Namespace, deployment.Name)
-	}
-	deploymentSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
-	if err != nil {
-		return nil, err
-	}
-
-	podList, err := ctx.KubeClient().KubeClient().CoreV1().Pods(primary.Pod.Namespace).List(ctx.Context(), metav1.ListOptions{
-		LabelSelector: deploymentSelector.String(),
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(podList.Items) == 0 {
-		return nil, fmt.Errorf("no pods found in deployment %s/%s", primary.Pod.Namespace, deployment.Name)
-	}
-
-	pods := make([]*kubeselector.SelectedPodContainer, 0, len(podList.Items))
-	for i := range podList.Items {
-		pod := podList.Items[i]
-		podDeploymentName, err := findDeploymentName(ctx.Context(), ctx.KubeClient(), &pod)
-		if err != nil {
-			return nil, err
-		}
-		if podDeploymentName != deploymentName {
-			continue
-		}
-		pods = append(pods, &kubeselector.SelectedPodContainer{
-			Pod:       &pod,
-			Container: primary.Container,
-		})
-	}
-	if len(pods) == 0 {
-		return nil, fmt.Errorf("no pods found in deployment %s/%s", primary.Pod.Namespace, deployment.Name)
-	}
-
-	sort.Slice(pods, func(i, j int) bool {
-		return kubeselector.SortContainersByNewest(pods, i, j)
-	})
-
-	targets = make([]syncTargetSelector, 0, len(pods))
-	for _, container := range pods {
-		targets = append(targets, syncTargetSelector{
-			selector: targetselector.NewTargetSelector(
-				targetselector.NewOptionsFromFlags(container.Container.Name, "", nil, container.Pod.Namespace, container.Pod.Name),
-			),
-			namespace: container.Pod.Namespace,
-			pod:       container.Pod.Name,
-			container: container.Container.Name,
-		})
-	}
-
-	ctx.Log().Infof("syncReplicas enabled: starting %d sync targets for path %s", len(targets), syncConfig.Path)
-	return targets, nil
-}
-
-func findDeploymentName(ctx context.Context, client kubectl.Client, pod *corev1.Pod) (string, error) {
-	for _, ownerRef := range pod.OwnerReferences {
-		if ownerRef.Kind == "Deployment" {
-			return ownerRef.Name, nil
-		}
-		if ownerRef.Kind == "ReplicaSet" {
-			replicaSet, err := client.KubeClient().AppsV1().ReplicaSets(pod.Namespace).Get(ctx, ownerRef.Name, metav1.GetOptions{})
-			if err != nil {
-				return "", err
-			}
-
-			for _, rsOwnerRef := range replicaSet.OwnerReferences {
-				if rsOwnerRef.Kind == "Deployment" {
-					return rsOwnerRef.Name, nil
-				}
-			}
-		}
-	}
-
-	return "", nil
-}
-
-func configForTarget(syncConfig *latest.SyncConfig, targetIndex int) *latest.SyncConfig {
-	copied := *syncConfig
-	if targetIndex > 0 {
-		copied.DisableDownload = true
-		copied.OnUpload = nil
-	}
-
-	return &copied
-}
-
-func syncReplicasEnabled(syncConfig *latest.SyncConfig) bool {
-	return syncConfig.SyncReplicas
 }
 
 // StartSync starts the syncing functionality
@@ -240,27 +108,25 @@ func StartSync(ctx devspacecontext.Context, devPod *latest.DevPod, selector targ
 }
 
 func startSync(ctx devspacecontext.Context, name, arch string, syncConfig *latest.SyncConfig, selector targetselector.TargetSelector, starter sync.DelayedContainerStarter, parent *tomb.Tomb) error {
-	targetSelectors, err := buildTargetSelectors(ctx, selector, syncConfig)
+	targets, err := synctarget.BuildTargets(ctx.Context(), ctx.Log(), ctx.KubeClient(), selector, syncConfig)
 	if err != nil {
 		return err
 	}
 
-	// Multiple replica targets must not share the dev session tomb: the sync controller
-	// calls parent.Kill on normal completion and errors, which would tear down every
-	// other sync (including other dev pods) mid-flight. Use an isolated tomb per target.
-	if len(targetSelectors) == 1 {
-		return startSyncOneTarget(ctx, name, arch, syncConfig, starter, parent, targetSelectors, 0)
+	// One tomb per replica: the sync controller calls Kill on it and would stop sibling syncs.
+	if len(targets) == 1 {
+		return startSyncOneTarget(ctx, name, arch, syncConfig, starter, parent, targets, 0)
 	}
 
 	var wg stdsync.WaitGroup
-	errs := make([]error, len(targetSelectors))
-	for i := range targetSelectors {
+	errs := make([]error, len(targets))
+	for i := range targets {
 		wg.Add(1)
 		i := i
 		go func() {
 			defer wg.Done()
 			var subTomb tomb.Tomb
-			errs[i] = startSyncOneTarget(ctx, name, arch, syncConfig, starter, &subTomb, targetSelectors, i)
+			errs[i] = startSyncOneTarget(ctx, name, arch, syncConfig, starter, &subTomb, targets, i)
 		}()
 	}
 	wg.Wait()
@@ -278,26 +144,26 @@ func startSyncOneTarget(
 	syncConfig *latest.SyncConfig,
 	starter sync.DelayedContainerStarter,
 	syncParent *tomb.Tomb,
-	targetSelectors []syncTargetSelector,
+	targets []synctarget.Target,
 	i int,
 ) error {
-	target := targetSelectors[i]
-	syncConfigForTarget := configForTarget(syncConfig, i)
-	if syncReplicasEnabled(syncConfig) && target.pod != "" && target.container != "" {
+	target := targets[i]
+	syncConfigForTarget := synctarget.ConfigForIndex(syncConfig, i)
+	if synctarget.ReplicasEnabled(syncConfig) && target.Pod != "" && target.Container != "" {
 		ctx.Log().Infof(
 			"Sync target %d/%d: %s/%s:%s (disableUpload=%t disableDownload=%t)",
 			i+1,
-			len(targetSelectors),
-			target.namespace,
-			target.pod,
-			target.container,
+			len(targets),
+			target.Namespace,
+			target.Pod,
+			target.Container,
 			syncConfigForTarget.DisableUpload,
 			syncConfigForTarget.DisableDownload,
 		)
 	}
 
 	effectiveStarter := starter
-	if syncReplicasEnabled(syncConfig) && (syncConfig.StartContainer || (syncConfig.OnUpload != nil && syncConfig.OnUpload.RestartContainer)) {
+	if synctarget.ReplicasEnabled(syncConfig) && (syncConfig.StartContainer || (syncConfig.OnUpload != nil && syncConfig.OnUpload.RestartContainer)) {
 		ts := sync.NewDelayedContainerStarter()
 		ts.Inc()
 		effectiveStarter = ts
@@ -305,7 +171,7 @@ func startSyncOneTarget(
 
 	options := &Options{
 		Name:       name,
-		Selector:   target.selector,
+		Selector:   target.Selector,
 		SyncConfig: syncConfigForTarget,
 		Arch:       arch,
 		Starter:    effectiveStarter,

--- a/pkg/devspace/services/sync/synctarget/expand.go
+++ b/pkg/devspace/services/sync/synctarget/expand.go
@@ -1,0 +1,144 @@
+package synctarget
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	kubeselector "github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
+	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
+	"github.com/loft-sh/devspace/pkg/util/log"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type Target struct {
+	Selector  targetselector.TargetSelector
+	Namespace string
+	Pod       string
+	Container string
+}
+
+// ReplicasEnabled returns true if syncReplicas is enabled on the config.
+func ReplicasEnabled(syncConfig *latest.SyncConfig) bool {
+	return syncConfig != nil && syncConfig.SyncReplicas
+}
+
+// ConfigForIndex returns sync config for replica index i (0 = primary, others upload-only).
+func ConfigForIndex(syncConfig *latest.SyncConfig, index int) *latest.SyncConfig {
+	copied := *syncConfig
+	if index > 0 {
+		copied.DisableDownload = true
+		copied.OnUpload = nil
+	}
+	return &copied
+}
+
+// BuildTargets returns sync targets; with syncReplicas, one per pod in the deployment.
+func BuildTargets(ctx context.Context, lg log.Logger, client kubectl.Client, selector targetselector.TargetSelector, syncConfig *latest.SyncConfig) ([]Target, error) {
+	targets := []Target{{Selector: selector}}
+	if !ReplicasEnabled(syncConfig) {
+		return targets, nil
+	}
+
+	primary, err := selector.SelectSingleContainer(ctx, client, lg)
+	if err != nil {
+		return nil, err
+	}
+	if primary == nil {
+		return nil, fmt.Errorf("couldn't find a pod / container with the configured selector")
+	}
+
+	deploymentName, err := DeploymentName(ctx, client, primary.Pod)
+	if err != nil {
+		return nil, err
+	}
+	if deploymentName == "" {
+		return nil, fmt.Errorf("pod %s/%s is not part of a deployment", primary.Pod.Namespace, primary.Pod.Name)
+	}
+
+	deployment, err := client.KubeClient().AppsV1().Deployments(primary.Pod.Namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+	if deployment.Spec.Selector == nil {
+		return nil, fmt.Errorf("deployment %s/%s has no selector", deployment.Namespace, deployment.Name)
+	}
+	deploymentSelector, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+	if err != nil {
+		return nil, err
+	}
+
+	podList, err := client.KubeClient().CoreV1().Pods(primary.Pod.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: deploymentSelector.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(podList.Items) == 0 {
+		return nil, fmt.Errorf("no pods found in deployment %s/%s", primary.Pod.Namespace, deployment.Name)
+	}
+
+	pods := make([]*kubeselector.SelectedPodContainer, 0, len(podList.Items))
+	for i := range podList.Items {
+		pod := podList.Items[i]
+		podDeploymentName, err := DeploymentName(ctx, client, &pod)
+		if err != nil {
+			return nil, err
+		}
+		if podDeploymentName != deploymentName {
+			continue
+		}
+		pods = append(pods, &kubeselector.SelectedPodContainer{
+			Pod:       &pod,
+			Container: primary.Container,
+		})
+	}
+	if len(pods) == 0 {
+		return nil, fmt.Errorf("no pods found in deployment %s/%s", primary.Pod.Namespace, deployment.Name)
+	}
+
+	sort.Slice(pods, func(i, j int) bool {
+		return kubeselector.SortContainersByNewest(pods, i, j)
+	})
+
+	targets = make([]Target, 0, len(pods))
+	for _, container := range pods {
+		targets = append(targets, Target{
+			Selector: targetselector.NewTargetSelector(
+				targetselector.NewOptionsFromFlags(container.Container.Name, "", nil, container.Pod.Namespace, container.Pod.Name),
+			),
+			Namespace: container.Pod.Namespace,
+			Pod:       container.Pod.Name,
+			Container: container.Container.Name,
+		})
+	}
+
+	lg.Infof("syncReplicas enabled: starting %d sync targets for path %s", len(targets), syncConfig.Path)
+	return targets, nil
+}
+
+// DeploymentName returns the owning Deployment name for a pod, if any.
+func DeploymentName(ctx context.Context, client kubectl.Client, pod *corev1.Pod) (string, error) {
+	for _, ownerRef := range pod.OwnerReferences {
+		if ownerRef.Kind == "Deployment" {
+			return ownerRef.Name, nil
+		}
+		if ownerRef.Kind == "ReplicaSet" {
+			replicaSet, err := client.KubeClient().AppsV1().ReplicaSets(pod.Namespace).Get(ctx, ownerRef.Name, metav1.GetOptions{})
+			if err != nil {
+				return "", err
+			}
+
+			for _, rsOwnerRef := range replicaSet.OwnerReferences {
+				if rsOwnerRef.Kind == "Deployment" {
+					return rsOwnerRef.Name, nil
+				}
+			}
+		}
+	}
+
+	return "", nil
+}

--- a/pkg/devspace/services/sync/synctarget/synctarget_test.go
+++ b/pkg/devspace/services/sync/synctarget/synctarget_test.go
@@ -1,0 +1,272 @@
+package synctarget
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"github.com/loft-sh/devspace/pkg/devspace/kubectl"
+	kubeselector "github.com/loft-sh/devspace/pkg/devspace/kubectl/selector"
+	kubectesting "github.com/loft-sh/devspace/pkg/devspace/kubectl/testing"
+	"github.com/loft-sh/devspace/pkg/devspace/services/targetselector"
+	"github.com/loft-sh/devspace/pkg/util/log"
+	fakelogger "github.com/loft-sh/devspace/pkg/util/log/testing"
+	"github.com/loft-sh/devspace/pkg/util/ptr"
+	"gotest.tools/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+type fakeTargetSelector struct {
+	out *kubeselector.SelectedPodContainer
+	err error
+}
+
+func (f *fakeTargetSelector) SelectSinglePod(ctx context.Context, client kubectl.Client, lg log.Logger) (*corev1.Pod, error) {
+	panic("not implemented")
+}
+
+func (f *fakeTargetSelector) SelectSingleContainer(ctx context.Context, client kubectl.Client, lg log.Logger) (*kubeselector.SelectedPodContainer, error) {
+	return f.out, f.err
+}
+
+func (f *fakeTargetSelector) WithContainer(container string) targetselector.TargetSelector {
+	return f
+}
+
+func testContainer(name string) *corev1.Container {
+	return &corev1.Container{Name: name, Image: "test:latest"}
+}
+
+func TestConfigForIndex_PrimaryIsBiDirectional(t *testing.T) {
+	base := &latest.SyncConfig{
+		DisableDownload: false,
+		DisableUpload:   true,
+		OnUpload:        &latest.SyncOnUpload{RestartContainer: true},
+	}
+	out := ConfigForIndex(base, 0)
+	assert.Equal(t, false, out.DisableDownload)
+	assert.Equal(t, true, out.DisableUpload)
+	assert.Assert(t, out.OnUpload != nil)
+	assert.Equal(t, true, out.OnUpload.RestartContainer)
+}
+
+func TestConfigForIndex_SecondaryIsUploadOnly(t *testing.T) {
+	base := &latest.SyncConfig{
+		DisableDownload: false,
+		DisableUpload:   false,
+		OnUpload:        &latest.SyncOnUpload{RestartContainer: true},
+	}
+	out := ConfigForIndex(base, 1)
+	assert.Equal(t, true, out.DisableDownload)
+	assert.Equal(t, false, out.DisableUpload)
+	assert.Assert(t, out.OnUpload == nil)
+}
+
+func TestBuildTargets_SyncReplicasOff_NoExpansion(t *testing.T) {
+	ctx := context.Background()
+	lg := fakelogger.NewFakeLogger()
+	kube := fake.NewSimpleClientset()
+	client := kubectesting.Client{Client: kube}
+	sel := targetselector.NewTargetSelector(targetselector.NewEmptyOptions())
+	cfg := &latest.SyncConfig{SyncReplicas: false, Path: "./:/app"}
+
+	targets, err := BuildTargets(ctx, lg, &client, sel, cfg)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(targets))
+	assert.Equal(t, "", targets[0].Pod)
+}
+
+func TestBuildTargets_SyncReplicasOn_OrdersNewestPodFirst(t *testing.T) {
+	ctx := context.Background()
+	lg := fakelogger.NewFakeLogger()
+	ns := "default"
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "web"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "web"}},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app", Image: "img:v1"}},
+				},
+			},
+		},
+	}
+
+	kube := fake.NewSimpleClientset(deploy)
+	dep, err := kube.AppsV1().Deployments(ns).Get(ctx, "web", metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	rs := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-rs",
+			Namespace: ns,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "web",
+				UID:        dep.UID,
+				Controller: ptr.Bool(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: deploy.Spec.Selector,
+			Template: deploy.Spec.Template,
+		},
+	}
+	rs, err = kube.AppsV1().ReplicaSets(ns).Create(ctx, rs, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	oldTime := metav1.NewTime(time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC))
+	newTime := metav1.NewTime(time.Date(2020, 6, 1, 0, 0, 0, 0, time.UTC))
+
+	podOlder := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "web-older",
+			Namespace:         ns,
+			Labels:            map[string]string{"app": "web"},
+			CreationTimestamp: oldTime,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       rs.Name,
+				UID:        rs.UID,
+				Controller: ptr.Bool(true),
+			}},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "img:v1"}},
+		},
+	}
+	podNewer := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "web-newer",
+			Namespace:         ns,
+			Labels:            map[string]string{"app": "web"},
+			CreationTimestamp: newTime,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       rs.Name,
+				UID:        rs.UID,
+				Controller: ptr.Bool(true),
+			}},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "img:v1"}},
+		},
+	}
+	_, err = kube.CoreV1().Pods(ns).Create(ctx, podOlder, metav1.CreateOptions{})
+	assert.NilError(t, err)
+	_, err = kube.CoreV1().Pods(ns).Create(ctx, podNewer, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	primary := &kubeselector.SelectedPodContainer{
+		Pod:       podNewer,
+		Container: testContainer("app"),
+	}
+	sel := &fakeTargetSelector{out: primary}
+	cfg := &latest.SyncConfig{SyncReplicas: true, Path: "./:/app"}
+
+	client := kubectesting.Client{Client: kube}
+	targets, err := BuildTargets(ctx, lg, &client, sel, cfg)
+	assert.NilError(t, err)
+	assert.Equal(t, 2, len(targets))
+	assert.Equal(t, "web-newer", targets[0].Pod)
+	assert.Equal(t, "web-older", targets[1].Pod)
+}
+
+func TestBuildTargets_FiltersPodsFromOtherDeploymentsWithSameLabels(t *testing.T) {
+	ctx := context.Background()
+	lg := fakelogger.NewFakeLogger()
+	ns := "default"
+	label := map[string]string{"app": "shared"}
+
+	deployA := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-a", Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: label},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: label},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "a"}}},
+			},
+		},
+	}
+	deployB := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "svc-b", Namespace: ns},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: label},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: label},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "b"}}},
+			},
+		},
+	}
+	kube := fake.NewSimpleClientset(deployA, deployB)
+
+	depA, err := kube.AppsV1().Deployments(ns).Get(ctx, "svc-a", metav1.GetOptions{})
+	assert.NilError(t, err)
+	depB, err := kube.AppsV1().Deployments(ns).Get(ctx, "svc-b", metav1.GetOptions{})
+	assert.NilError(t, err)
+
+	rsA := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc-a-rs", Namespace: ns,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: "svc-a", UID: depA.UID, Controller: ptr.Bool(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{Selector: deployA.Spec.Selector, Template: deployA.Spec.Template},
+	}
+	rsB := &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "svc-b-rs", Namespace: ns,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: "svc-b", UID: depB.UID, Controller: ptr.Bool(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{Selector: deployB.Spec.Selector, Template: deployB.Spec.Template},
+	}
+	rsA, err = kube.AppsV1().ReplicaSets(ns).Create(ctx, rsA, metav1.CreateOptions{})
+	assert.NilError(t, err)
+	rsB, err = kube.AppsV1().ReplicaSets(ns).Create(ctx, rsB, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	podA := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-a", Namespace: ns, Labels: label,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "ReplicaSet", Name: rsA.Name, UID: rsA.UID, Controller: ptr.Bool(true),
+			}},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "a"}}},
+	}
+	podB := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "pod-b", Namespace: ns, Labels: label,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "ReplicaSet", Name: rsB.Name, UID: rsB.UID, Controller: ptr.Bool(true),
+			}},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "b"}}},
+	}
+	_, err = kube.CoreV1().Pods(ns).Create(ctx, podA, metav1.CreateOptions{})
+	assert.NilError(t, err)
+	_, err = kube.CoreV1().Pods(ns).Create(ctx, podB, metav1.CreateOptions{})
+	assert.NilError(t, err)
+
+	primary := &kubeselector.SelectedPodContainer{Pod: podA, Container: testContainer("app")}
+	sel := &fakeTargetSelector{out: primary}
+	cfg := &latest.SyncConfig{SyncReplicas: true, Path: "./:/app"}
+
+	client := kubectesting.Client{Client: kube}
+	targets, err := BuildTargets(ctx, lg, &client, sel, cfg)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(targets))
+	assert.Equal(t, "pod-a", targets[0].Pod)
+}


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 

/kind feature
/kind enhancement
/kind test

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 

resolves #1250 (Closed issue, but I can create a separate issue detailing use-cases where this is useful)


**Please provide a short message that should be published in the DevSpace release notes**

Support multi-pod sync over Kubernetes deployments (ReplicaSet, Deployments, StatefulSet)


**What else do we need to know?** 

- Feature is Opt-in: `syncReplicas: boolean` in config and/or `--sync-replicas` on dev sync
- Non-primary replicas: upload-only, no download (by design)
    * Primary pod selection: defined as the newest pod
    * Secondary pod restrictions: _configured with upload only to stop infinite sync loops_.
- Pod replacement: preserves replica count when any sync has `syncReplicas: true`
- Adds E2E test with `sync-replicas` testdata
- Breaking changes: none expected for default configurations.

---

**Note from me**

The goal of this change is to make dev pipeline options *(image, command, and the rest)* not mutually exclusive with syncing multiple replicas—something that today is only achievable via bespoke bash scripting outside of Devspace.

I am fairly new to Go, so feedback on style and structure is very welcome. If this PR does not align with the goals of the application, feel free to drop it entirely. 

Thanks