### PR TITLE
fix: prevent nil map panic when docker-compose.yaml has top-level name field

### DIFF
--- a/pkg/devspace/compose/manager.go
+++ b/pkg/devspace/compose/manager.go
@@ -44,6 +44,7 @@ func LoadDockerComposeProject(path string) (*composetypes.Project, error) {
 				Content: composeFile,
 			},
 		},
+		Environment: map[string]string{},
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/devspace/compose/testdata/named_project/devspace.yaml
+++ b/pkg/devspace/compose/testdata/named_project/devspace.yaml
@@ -1,0 +1,9 @@
+version: v2beta1
+name: docker-compose
+deployments:
+  web:
+    helm:
+      values:
+        containers:
+          - name: web-container
+            image: nginx:latest

--- a/pkg/devspace/compose/testdata/named_project/docker-compose.yaml
+++ b/pkg/devspace/compose/testdata/named_project/docker-compose.yaml
@@ -1,0 +1,4 @@
+name: myproject
+services:
+  web:
+    image: nginx:latest


### PR DESCRIPTION
## Summary

Fixes #2970

When a `docker-compose.yaml` includes a top-level `name:` field (e.g. `name: myproject`), `devspace init` panics with:

```
panic: assignment to entry in nil map
```

## Root Cause

In `pkg/devspace/compose/manager.go`, `LoadDockerComposeProject` passes a `ConfigDetails` struct to the compose-go loader without initializing the `Environment` field. When the compose file has a `name:` field, the loader tries to write to `configDetails.Environment` (in `vendor/.../loader/loader.go` line 218), which is `nil`.

## Fix

Initialize `Environment` to an empty map in the `ConfigDetails` struct passed to `composeloader.Load()`.

## Testing

- Added a new `named_project` test case under `pkg/devspace/compose/testdata/` with a `docker-compose.yaml` containing `name: myproject`
- All existing compose tests continue to pass
- The new test case triggers the previously-panicking code path and now succeeds