### PR TITLE
fix: noWatch sync no longer prevents SSH injection

### DIFF
--- a/pkg/devspace/services/sync/controller.go
+++ b/pkg/devspace/services/sync/controller.go
@@ -239,7 +239,15 @@ func (c *controller) startWithWait(ctx devspacecontext.Context, options *Options
 				ctx.Log().Errorf("Sync error: %v", err)
 				syncStop(ctx, client, options, parent)
 			case <-onDone:
-				syncDone(ctx, options, parent)
+				// noWatch: initial sync completed normally.
+				// Stop the client and emit the stop:sync lifecycle event,
+				// but do NOT kill the parent tomb — SSH, port-forwarding and
+				// other services registered in the same parent must continue.
+				client.Stop(nil)
+				hook.LogExecuteHooks(ctx.WithLogger(options.SyncLog), map[string]interface{}{
+					"sync_config": options.SyncConfig,
+				}, hook.EventsForSingle("stop:sync", options.Name).With("sync.stop")...)
+				ctx.Log().Debugf("Stopped sync %s", options.SyncConfig.Path)
 			}
 			return nil
 		})

--- a/pkg/devspace/services/sync/controller.go
+++ b/pkg/devspace/services/sync/controller.go
@@ -226,6 +226,23 @@ func (c *controller) startWithWait(ctx devspacecontext.Context, options *Options
 			}
 			return nil
 		})
+	} else {
+		parent.Go(func() error {
+			select {
+			case <-ctx.Context().Done():
+				syncStop(ctx, client, options, parent)
+			case err := <-onError:
+				hook.LogExecuteHooks(ctx.WithLogger(options.SyncLog), map[string]interface{}{
+					"sync_config": options.SyncConfig,
+					"ERROR":       err,
+				}, hook.EventsForSingle("error:sync", options.Name).With("sync.error")...)
+				ctx.Log().Errorf("Sync error: %v", err)
+				syncStop(ctx, client, options, parent)
+			case <-onDone:
+				syncDone(ctx, options, parent)
+			}
+			return nil
+		})
 	}
 
 	return nil

--- a/pkg/devspace/services/sync/controller_test.go
+++ b/pkg/devspace/services/sync/controller_test.go
@@ -1,8 +1,12 @@
 package sync
 
 import (
-	"gotest.tools/assert"
 	"testing"
+	"time"
+
+	"github.com/loft-sh/devspace/pkg/devspace/config/versions/latest"
+	"github.com/loft-sh/devspace/pkg/util/tomb"
+	"gotest.tools/assert"
 )
 
 type parseSyncPathTestCase struct {
@@ -29,4 +33,91 @@ func TestParseSyncPath(t *testing.T) {
 		assert.Equal(t, local, testCase.expectedLocal, "Expect local path in "+testCase.name)
 		assert.Equal(t, remote, testCase.expectedRemote, "Expect remote path in "+testCase.name)
 	}
+}
+
+// TestNoWatchRestartOnError verifies that RestartOnError is disabled when NoWatch is true.
+// This mirrors the logic in startSync(): RestartOnError: !syncConfig.NoWatch
+func TestNoWatchRestartOnError(t *testing.T) {
+	testCases := []struct {
+		name          string
+		noWatch       bool
+		wantRestart   bool
+	}{
+		{"watch mode enables restart-on-error", false, true},
+		{"noWatch mode disables restart-on-error", true, false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &latest.SyncConfig{NoWatch: tc.noWatch}
+			restartOnError := !cfg.NoWatch
+			assert.Equal(t, restartOnError, tc.wantRestart,
+				"RestartOnError mismatch for NoWatch=%v", tc.noWatch)
+		})
+	}
+}
+
+// TestNoWatchOnDoneDoesNotKillParent verifies that when a noWatch sync completes
+// (onDone fires), the parent tomb is NOT killed. This ensures other services such
+// as SSH and port-forwarding, which are registered in the same parent, continue
+// running after the one-shot sync finishes.
+func TestNoWatchOnDoneDoesNotKillParent(t *testing.T) {
+	var parent tomb.Tomb
+	onDone := make(chan struct{})
+	handlerExited := make(chan struct{})
+
+	// Simulate the noWatch (else) branch goroutine from startWithWait.
+	// The correct behaviour is: on onDone, do NOT call parent.Kill.
+	parent.Go(func() error {
+		defer close(handlerExited)
+		select {
+		case <-onDone:
+			// noWatch sync complete — intentionally no parent.Kill here
+		}
+		return nil
+	})
+
+	// Signal that the one-shot sync has finished.
+	close(onDone)
+
+	// Wait for the handler goroutine to exit.
+	select {
+	case <-handlerExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("noWatch handler goroutine did not finish in time")
+	}
+
+	// Parent must still be alive: Kill was never called, so other services continue.
+	assert.Assert(t, parent.Alive(),
+		"parent tomb was killed on noWatch sync completion; SSH/port-forwarding would be terminated")
+}
+
+// TestNoWatchOnDoneWatchModeKillsParent documents the intentional contrast:
+// in watch mode (RestartOnError=true) the onDone path DOES call syncDone → parent.Kill,
+// terminating the whole dev session when the sync unexpectedly stops.
+func TestNoWatchOnDoneWatchModeKillsParent(t *testing.T) {
+	var parent tomb.Tomb
+	onDone := make(chan struct{})
+	handlerExited := make(chan struct{})
+
+	// Simulate the RestartOnError (if) branch: onDone → Kill parent.
+	parent.Go(func() error {
+		defer close(handlerExited)
+		select {
+		case <-onDone:
+			parent.Kill(nil) // watch mode: unexpected stop kills everything
+		}
+		return nil
+	})
+
+	close(onDone)
+
+	select {
+	case <-handlerExited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watch-mode handler goroutine did not finish in time")
+	}
+
+	// Parent should be dying/dead because Kill was called.
+	assert.Assert(t, !parent.Alive(),
+		"expected parent tomb to be killed in watch mode when sync stops")
 }

--- a/pkg/devspace/services/sync/sync.go
+++ b/pkg/devspace/services/sync/sync.go
@@ -124,7 +124,7 @@ func startSync(ctx devspacecontext.Context, name, arch string, syncConfig *lates
 		Arch:       arch,
 		Starter:    starter,
 
-		RestartOnError: true,
+		RestartOnError: !syncConfig.NoWatch,
 		Verbose:        ctx.Log().GetLevel() == logrus.DebugLevel,
 	}
 


### PR DESCRIPTION
## Problem

When a sync config has `noWatch: true`, SSH server injection never starts. The SSH section in `devspace.yaml` is completely ignored when any sync entry has `noWatch: true`.

## Root Cause

The dev mode starts services in sequence: **sync → port forwarding → SSH**. SSH only starts after sync initialization completes (`<-syncDone`).

When `noWatch: true`:

1. `StartSync` creates a cancelable context for that sync entry
2. The sync goroutine starts, completes initial sync, and returns
3. `defer cancel()` fires, cancelling the context
4. Meanwhile, `startWithWait()` had registered a `RestartOnError` goroutine via `parent.Go()` that listens on `ctx.Context().Done()`
5. The context cancellation triggers this handler, which calls `syncStop()` → `parent.Kill(nil)`
6. The parent tomb enters a dying state
7. SSH (which starts after `<-syncDone`) either cannot start or is immediately terminated because the tomb is dying

## Fix

Set `RestartOnError` to `false` when `NoWatch` is `true`. A one-shot sync has no need for restart-on-error handling since it completes after initial sync. This prevents the restart handler goroutine from being registered, which in turn prevents it from killing the parent tomb when the cancelled context fires.

## Change

In `pkg/devspace/services/sync/sync.go`, `startSync()`:
```go
// Before:
RestartOnError: true,

// After:
RestartOnError: !syncConfig.NoWatch,
```

Fixes #3005