### PR TITLE
fix: use -OutFile instead of ambiguous -o in PowerShell install command

### DIFF
--- a/docs/pages/_partials/install-cli.mdx
+++ b/docs/pages/_partials/install-cli.mdx
@@ -63,7 +63,7 @@ curl -L -o devspace "https://github.com/loft-sh/devspace/releases/latest/downloa
 
 ```powershell
 md -Force "$Env:APPDATA\devspace"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-Invoke-WebRequest -URI "https://github.com/loft-sh/devspace/releases/latest/download/devspace-windows-amd64.exe" -o $Env:APPDATA\devspace\devspace.exe;
+Invoke-WebRequest -URI "https://github.com/loft-sh/devspace/releases/latest/download/devspace-windows-amd64.exe" -OutFile $Env:APPDATA\devspace\devspace.exe;
 $env:Path += ";" + $Env:APPDATA + "\devspace";
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
 ```

--- a/docs/versioned_docs/version-4.x/getting-started/installation.mdx
+++ b/docs/versioned_docs/version-4.x/getting-started/installation.mdx
@@ -48,7 +48,7 @@ curl -L -o devspace "https://github.com/loft-sh/devspace/releases/latest/downloa
 
 ```powershell {4}
 md -Force "$Env:APPDATA\loft"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-Invoke-WebRequest -URI "https://github.com/loft-sh/devspace/releases/latest/download/devspace-windows-amd64.exe" -o $Env:APPDATA\loft\devspace.exe;
+Invoke-WebRequest -URI "https://github.com/loft-sh/devspace/releases/latest/download/devspace-windows-amd64.exe" -OutFile $Env:APPDATA\loft\devspace.exe;
 $env:Path += ";" + $Env:APPDATA + "\loft";
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
 ```

--- a/docs/versioned_docs/version-5.x/fragments/install-cli.mdx
+++ b/docs/versioned_docs/version-5.x/fragments/install-cli.mdx
@@ -62,7 +62,7 @@ curl -L -o devspace "https://github.com/loft-sh/devspace/releases/latest/downloa
 
 ```powershell {4}
 md -Force "$Env:APPDATA\devspace"; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12';
-Invoke-WebRequest -URI "https://github.com/loft-sh/devspace/releases/latest/download/devspace-windows-amd64.exe" -o $Env:APPDATA\devspace\devspace.exe;
+Invoke-WebRequest -URI "https://github.com/loft-sh/devspace/releases/latest/download/devspace-windows-amd64.exe" -OutFile $Env:APPDATA\devspace\devspace.exe;
 $env:Path += ";" + $Env:APPDATA + "\devspace";
 [Environment]::SetEnvironmentVariable("Path", $env:Path, [System.EnvironmentVariableTarget]::User);
 ```


### PR DESCRIPTION
### Description

Replace the ambiguous `-o` parameter with the full `-OutFile` parameter in PowerShell installation commands.

### Problem

In PowerShell 7.6.0+, the `-o` shorthand for `Invoke-WebRequest` is ambiguous because it matches multiple parameters:
- `-OperationTimeoutSeconds`
- `-OutFile`
- `-OutVariable`
- `-OutBuffer`

This causes the installation command to fail with:
```
Invoke-WebRequest: Parameter cannot be processed because the parameter name 'o' is ambiguous.
```

### Fix

Replace `-o` with the full `-OutFile` parameter in all 3 installation documentation files:
- `docs/pages/_partials/install-cli.mdx`
- `docs/versioned_docs/version-4.x/getting-started/installation.mdx`
- `docs/versioned_docs/version-5.x/fragments/install-cli.mdx`

Fixes #3199