### PR TITLE
fix: recover from panic in IsMinikubeKubernetes when kubeconfig extensions are plain strings

### DIFF
--- a/pkg/devspace/kubectl/util.go
+++ b/pkg/devspace/kubectl/util.go
@@ -272,6 +272,11 @@ func IsMinikubeKubernetes(kubeClient Client) bool {
 // panics on such values via reflection ("reflect.Set: value of type string is
 // not assignable to type map[string]interface {}") rather than returning an
 // error, so we recover() and treat unparseable extensions as non-minikube.
+//
+// noinline is required: if the compiler inlines this function into its caller,
+// the deferred recover() loses its stack frame and cannot catch the panic.
+//
+//go:noinline
 func isMinikubeExtension(extension runtime.Object) (result bool) {
 	defer func() {
 		if recover() != nil {

--- a/pkg/devspace/kubectl/util.go
+++ b/pkg/devspace/kubectl/util.go
@@ -255,18 +255,35 @@ func IsMinikubeKubernetes(kubeClient Client) bool {
 	if rawConfig, err := kubeClient.ClientConfig().RawConfig(); err == nil {
 		clusters := rawConfig.Clusters[rawConfig.Contexts[rawConfig.CurrentContext].Cluster]
 		for _, extension := range clusters.Extensions {
-			ext, err := runtime.DefaultUnstructuredConverter.ToUnstructured(extension)
-			if err == nil {
-				if provider, ok := ext["provider"].(string); ok {
-					if provider == minikubeProvider {
-						return true
-					}
-				}
+			if isMinikubeExtension(extension) {
+				return true
 			}
 		}
 	}
 
 	return false
+}
+
+// isMinikubeExtension safely checks whether a kubeconfig cluster extension
+// identifies the cluster as a minikube provider.
+//
+// Some tools (e.g. Teleport) write extension values as plain YAML strings
+// rather than structured objects. runtime.DefaultUnstructuredConverter.ToUnstructured
+// panics on such values via reflection ("reflect.Set: value of type string is
+// not assignable to type map[string]interface {}") rather than returning an
+// error, so we recover() and treat unparseable extensions as non-minikube.
+func isMinikubeExtension(extension runtime.Object) (result bool) {
+	defer func() {
+		if recover() != nil {
+			result = false
+		}
+	}()
+	ext, err := runtime.DefaultUnstructuredConverter.ToUnstructured(extension)
+	if err != nil {
+		return false
+	}
+	provider, ok := ext["provider"].(string)
+	return ok && provider == minikubeProvider
 }
 
 // GetKindContext returns the kind cluster name

--- a/pkg/devspace/kubectl/util.go
+++ b/pkg/devspace/kubectl/util.go
@@ -2,6 +2,7 @@ package kubectl
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -264,27 +265,13 @@ func IsMinikubeKubernetes(kubeClient Client) bool {
 	return false
 }
 
-// isMinikubeExtension safely checks whether a kubeconfig cluster extension
-// identifies the cluster as a minikube provider.
-//
-// Some tools (e.g. Teleport) write extension values as plain YAML strings
-// rather than structured objects. runtime.DefaultUnstructuredConverter.ToUnstructured
-// panics on such values via reflection ("reflect.Set: value of type string is
-// not assignable to type map[string]interface {}") rather than returning an
-// error, so we recover() and treat unparseable extensions as non-minikube.
-//
-// noinline is required: if the compiler inlines this function into its caller,
-// the deferred recover() loses its stack frame and cannot catch the panic.
-//
-//go:noinline
-func isMinikubeExtension(extension runtime.Object) (result bool) {
-	defer func() {
-		if recover() != nil {
-			result = false
-		}
-	}()
-	ext, err := runtime.DefaultUnstructuredConverter.ToUnstructured(extension)
-	if err != nil {
+func isMinikubeExtension(extension runtime.Object) bool {
+	unknown, ok := extension.(*runtime.Unknown)
+	if !ok {
+		return false
+	}
+	var ext map[string]interface{}
+	if err := json.Unmarshal(unknown.Raw, &ext); err != nil {
 		return false
 	}
 	provider, ok := ext["provider"].(string)

--- a/pkg/devspace/kubectl/util_test.go
+++ b/pkg/devspace/kubectl/util_test.go
@@ -1,0 +1,132 @@
+package kubectl
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"github.com/loft-sh/devspace/pkg/util/kubeconfig"
+	"gotest.tools/assert"
+	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// minimalClient implements kubectl.Client with only the two methods that
+// IsMinikubeKubernetes actually calls. All other methods panic if invoked.
+type minimalClient struct {
+	context      string
+	clientConfig clientcmd.ClientConfig
+}
+
+func (c *minimalClient) CurrentContext() string                   { return c.context }
+func (c *minimalClient) ClientConfig() clientcmd.ClientConfig    { return c.clientConfig }
+func (c *minimalClient) KubeClient() kubernetes.Interface        { panic("not implemented") }
+func (c *minimalClient) Namespace() string                       { panic("not implemented") }
+func (c *minimalClient) RestConfig() *rest.Config                { panic("not implemented") }
+func (c *minimalClient) KubeConfigLoader() kubeconfig.Loader     { panic("not implemented") }
+func (c *minimalClient) IsInCluster() bool                       { panic("not implemented") }
+func (c *minimalClient) CopyFromReader(_ context.Context, _ *k8sv1.Pod, _, _ string, _ io.Reader) error {
+	panic("not implemented")
+}
+func (c *minimalClient) Copy(_ context.Context, _ *k8sv1.Pod, _, _, _ string, _ []string) error {
+	panic("not implemented")
+}
+func (c *minimalClient) ExecStream(_ context.Context, _ *ExecStreamOptions) error {
+	panic("not implemented")
+}
+func (c *minimalClient) ExecBuffered(_ context.Context, _ *k8sv1.Pod, _ string, _ []string, _ io.Reader) ([]byte, []byte, error) {
+	panic("not implemented")
+}
+func (c *minimalClient) ExecBufferedCombined(_ context.Context, _ *k8sv1.Pod, _ string, _ []string, _ io.Reader) ([]byte, error) {
+	panic("not implemented")
+}
+func (c *minimalClient) GenericRequest(_ context.Context, _ *GenericRequestOptions) (string, error) {
+	panic("not implemented")
+}
+func (c *minimalClient) ReadLogs(_ context.Context, _, _, _ string, _ bool, _ *int64) (string, error) {
+	panic("not implemented")
+}
+func (c *minimalClient) Logs(_ context.Context, _, _, _ string, _ bool, _ *int64, _ bool) (io.ReadCloser, error) {
+	panic("not implemented")
+}
+func (c *minimalClient) EnsureNamespace(_ context.Context, _ string, _ interface{ Debug(args ...interface{}) }) error {
+	panic("not implemented")
+}
+
+// makeClient builds a test Client whose current context points at a cluster
+// with the given extensions map.
+func makeClient(contextName string, extensions map[string]runtime.Object) *minimalClient {
+	apiCfg := clientcmdapi.NewConfig()
+	apiCfg.Clusters[contextName] = &clientcmdapi.Cluster{
+		Server:     "https://example.test:6443",
+		Extensions: extensions,
+	}
+	apiCfg.Contexts[contextName] = &clientcmdapi.Context{
+		Cluster: contextName,
+	}
+	apiCfg.CurrentContext = contextName
+
+	cfg := clientcmd.NewNonInteractiveClientConfig(
+		*apiCfg,
+		contextName,
+		&clientcmd.ConfigOverrides{},
+		nil,
+	)
+	return &minimalClient{context: contextName, clientConfig: cfg}
+}
+
+func TestIsMinikubeKubernetes(t *testing.T) {
+	t.Run("nil client returns false", func(t *testing.T) {
+		assert.Equal(t, false, IsMinikubeKubernetes(nil))
+	})
+
+	t.Run("nil ClientConfig returns false", func(t *testing.T) {
+		c := &minimalClient{context: "some-cluster", clientConfig: nil}
+		assert.Equal(t, false, IsMinikubeKubernetes(c))
+	})
+
+	t.Run("context named 'minikube' returns true", func(t *testing.T) {
+		c := makeClient(minikubeContext, nil)
+		assert.Equal(t, true, IsMinikubeKubernetes(c))
+	})
+
+	t.Run("non-minikube context with no extensions returns false", func(t *testing.T) {
+		c := makeClient("my-cluster", nil)
+		assert.Equal(t, false, IsMinikubeKubernetes(c))
+	})
+
+	t.Run("cluster extension with minikube provider returns true", func(t *testing.T) {
+		ext := &runtime.Unknown{
+			Raw:         []byte(`{"provider":"minikube.sigs.k8s.io"}`),
+			ContentType: runtime.ContentTypeJSON,
+		}
+		c := makeClient("my-cluster", map[string]runtime.Object{minikubeProvider: ext})
+		assert.Equal(t, true, IsMinikubeKubernetes(c))
+	})
+
+	t.Run("cluster extension with different provider returns false", func(t *testing.T) {
+		ext := &runtime.Unknown{
+			Raw:         []byte(`{"provider":"some-other-provider"}`),
+			ContentType: runtime.ContentTypeJSON,
+		}
+		c := makeClient("my-cluster", map[string]runtime.Object{"some-other-provider": ext})
+		assert.Equal(t, false, IsMinikubeKubernetes(c))
+	})
+
+	// Some tools (e.g. Teleport) serialise kubeconfig extensions as plain YAML
+	// strings rather than structured objects. runtime.ToUnstructured panics on
+	// these via reflection instead of returning an error. isMinikubeExtension
+	// must recover gracefully and return false.
+	t.Run("string-valued extension does not panic and returns false", func(t *testing.T) {
+		ext := &runtime.Unknown{
+			Raw:         []byte(`"my-cluster-name"`), // bare JSON string, not an object
+			ContentType: runtime.ContentTypeJSON,
+		}
+		c := makeClient("my-cluster", map[string]runtime.Object{"example.dev/cluster-name": ext})
+		assert.Equal(t, false, IsMinikubeKubernetes(c))
+	})
+}

--- a/pkg/devspace/kubectl/util_test.go
+++ b/pkg/devspace/kubectl/util_test.go
@@ -118,9 +118,9 @@ func TestIsMinikubeKubernetes(t *testing.T) {
 	})
 
 	// Some tools (e.g. Teleport) serialise kubeconfig extensions as plain YAML
-	// strings rather than structured objects. runtime.ToUnstructured panics on
-	// these via reflection instead of returning an error. isMinikubeExtension
-	// must recover gracefully and return false.
+	// strings rather than structured objects. isMinikubeExtension detects this
+	// by type-asserting the extension to *runtime.Unknown and using json.Unmarshal,
+	// which returns an error for non-object JSON (e.g. a bare string) rather than panicking.
 	t.Run("string-valued extension does not panic and returns false", func(t *testing.T) {
 		ext := &runtime.Unknown{
 			Raw:         []byte(`"my-cluster-name"`), // bare JSON string, not an object


### PR DESCRIPTION
## Problem

When using a Teleport-managed kubeconfig, `devspace build` (and any pipeline that calls `build_images`) panics and crashes:

```
panic: reflect.Set: value of type string is not assignable to type map[string]interface {}

goroutine 123 [running]:
k8s.io/apimachinery/pkg/runtime.toUnstructured(...)
    vendor/k8s.io/apimachinery/pkg/runtime/converter.go:660
k8s.io/apimachinery/pkg/runtime.(*unstructuredConverter).ToUnstructured(...)
    vendor/k8s.io/apimachinery/pkg/runtime/converter.go:586
github.com/loft-sh/devspace/pkg/devspace/kubectl.IsMinikubeKubernetes(...)
    pkg/devspace/kubectl/util.go:258
github.com/loft-sh/devspace/pkg/devspace/kubectl.IsLocalKubernetes(...)
    pkg/devspace/kubectl/util.go:217
github.com/loft-sh/devspace/pkg/devspace/build/builder/buildkit.(*Builder).BuildImage(...)
    pkg/devspace/build/builder/buildkit/buildkit.go:111
```

## Root cause

Teleport writes kubeconfig cluster extensions as plain YAML strings, e.g.:

```yaml
clusters:
  - cluster:
      extensions:
        - name: teleport.kube.name
          extension: some-cluster-name   # <-- bare string, not an object
```

The Kubernetes spec says extension values should be structured objects. `runtime.DefaultUnstructuredConverter.ToUnstructured()` uses reflection and assumes the extension value is a struct/map — it panics (rather than returning an error) when it encounters a plain string.

## Fix

Extract the per-extension check into a small helper `isMinikubeExtension` that wraps the `ToUnstructured` call with `recover()`. A malformed/unparseable extension is treated as non-minikube and the build proceeds normally. No behaviour change on the happy path.

## Reproduction

1. Update a cluster's extension to be string-valued
2. Attempt e.g. `devspace build`
3. Observe the panic

Confirmed on devspace v6.3.2 and v6.3.20.

Resolves #3218.