### PR TITLE
Adds check for websocket source

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -24,8 +24,8 @@ jobs:
     strategy:
       matrix:
         kubernetes_version:
-          - v1.27.3
-          - v1.28.0
+          - v1.35.0
+          - v1.34.3
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - name: Checkout repo
@@ -36,11 +36,11 @@ jobs:
       with:
         version: ${{ matrix.kubernetes_version }}
 
-    # Creates KinD with using k8s versions from the matrix above
-    - name: Set up kind with K8s version v1.22.4
+    # Creates kind using the Kubernetes versions from the matrix above
+    - name: Set up kind cluster
       uses: engineerd/setup-kind@v0.5.0
       with:
-        version: "v0.20.0"
+        version: "v0.31.0"
         image: kindest/node:${{ matrix.kubernetes_version }}
 
     - name: Testing kind cluster set-up
@@ -53,8 +53,8 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.24"
-        
+        go-version: "1.25"
+
     - name: Build devspacehelper
       run: |
         mkdir -p ~/.devspace/devspacehelper/latest

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,13 +17,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-      - uses: actions/checkout@v3
+          go-version: "1.25"
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v7
         with:
+          version: v2.11.4
           args:
             -v
             --config=.golangci.yml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,13 +17,15 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
-      - uses: actions/checkout@v3
+          go-version: "1.25"
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v3.2.0
+        uses: golangci/golangci-lint-action@v7
         with:
+          version: v2.11.4
+          only-new-issues: true
           args:
             -v
             --config=.golangci.yml

--- a/.github/workflows/npm.yaml
+++ b/.github/workflows/npm.yaml
@@ -12,10 +12,10 @@ jobs:
   linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: |
           npm install -g
@@ -35,10 +35,10 @@ jobs:
   windows:
     runs-on: windows-2019
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 12
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: |
           npm install -g

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.25"
       - id: get_version
         run: |
           RELEASE_VERSION=$(echo $GITHUB_REF | sed -nE 's!refs/tags/!!p')

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
@@ -40,12 +40,12 @@ jobs:
   test-unit-windows:
     runs-on: windows-latest
     name: unit-test-windows-latest
-    
+
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
       
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -35,7 +35,10 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Test
-        run: ./hack/coverage.bash
+        shell: bash
+        run: |
+          source ./hack/remove-system-helm.sh
+          ./hack/coverage.bash
 
   test-unit-windows:
     runs-on: windows-latest
@@ -46,10 +49,12 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: "1.25"
-      
+
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
 
       - name: Test
-        run: ./hack/coverage.bash
         shell: bash
+        run: |
+          source ./hack/remove-system-helm.sh
+          ./hack/coverage.bash

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,33 +1,29 @@
+version: "2"
+
 run:
   timeout: 10m
 
-issues:
-  exclude-dirs:
-  - hack/
-  - docs/
-
 linters:
-  disable-all:  true
+  default: none
   enable:
     # - deadcode # deprecated https://github.com/golangci/golangci-lint/issues/1841
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - unused
     # - varcheck # deprecated https://github.com/golangci/golangci-lint/issues/1841
-    - staticcheck
+    - staticcheck # includes gosimple and stylecheck in v2
     - errcheck
     # - goimports
     - dupl
     - nakedret
-    - stylecheck
     # - gofmt
     # - golint
     # - structcheck # deprecated https://github.com/golangci/golangci-lint/issues/1841
-  
-linters-settings:
-  gofmt:
-    simplify: true
-  dupl:
-    threshold: 400
+  settings:
+    dupl:
+      threshold: 400
+  exclusions:
+    paths:
+      - hack/
+      - docs/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,33 +1,30 @@
+version: "2"
+
 run:
   timeout: 10m
 
-issues:
-  exclude-dirs:
-  - hack/
-  - docs/
-
 linters:
-  disable-all:  true
+  default: none
   enable:
     # - deadcode # deprecated https://github.com/golangci/golangci-lint/issues/1841
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - unused
     # - varcheck # deprecated https://github.com/golangci/golangci-lint/issues/1841
-    - staticcheck
+    - staticcheck # includes gosimple and stylecheck in v2
     - errcheck
     # - goimports
     - dupl
     - nakedret
-    - stylecheck
     # - gofmt
     # - golint
     # - structcheck # deprecated https://github.com/golangci/golangci-lint/issues/1841
-  
-linters-settings:
-  gofmt:
-    simplify: true
-  dupl:
-    threshold: 400
+  settings:
+    dupl:
+      threshold: 400
+  exclusions:
+    paths:
+      - hack/
+      - docs/
+      - assets/assets.go

--- a/dist/npm/bin/devspace
+++ b/dist/npm/bin/devspace
@@ -11,15 +11,17 @@ if [ ! -f "$BINARY" ] || [ "$STAT" -lt 10000 ]; then
     INDEX_FILE="/index.js"
 
     if [ ! -f "$BASEDIR/$INDEX_FILE" ]; then
-        BASEDIR="$(dirname $0)/../lib/node_modules/devspace"
+        BASEDIR="$(dirname $0)/../devspace"
 
         if [ ! -f "$BASEDIR/$INDEX_FILE" ]; then
-            BASEDIR="$(dirname $0)/node_modules/devspace"
+            BASEDIR="$(dirname $0)/../lib/node_modules/devspace"
 
             if [ ! -f "$BASEDIR/$INDEX_FILE" ]; then
-                BASEDIR=$(/usr/bin/env npm root -g)/devspace
+                BASEDIR="$(dirname $0)/node_modules/devspace"
 
                 if [ ! -f "$BASEDIR/$INDEX_FILE" ]; then
+                    BASEDIR=$(/usr/bin/env npm root -g)/devspace
+
                     if [ ! -f "$BASEDIR/$INDEX_FILE" ]; then
                         BASEDIR=$(/usr/bin/env yarn global dir)/node_modules/devspace
 

--- a/dist/npm/bin/devspace.cmd
+++ b/dist/npm/bin/devspace.cmd
@@ -13,24 +13,28 @@ SET indexFile=\index.js
 echo "!basedir!\!indexFile!"
 
 IF NOT EXIST "!basedir!\!indexFile!" (
-  SET basedir=%~dp0\..\lib\node_modules\devspace
+  SET basedir=%~dp0\..\devspace
 
   IF NOT EXIST "!basedir!\!indexFile!" (
-    SET basedir=%~dp0\node_modules\devspace
+    SET basedir=%~dp0\..\lib\node_modules\devspace
 
     IF NOT EXIST "!basedir!\!indexFile!" (
-      FOR /F "tokens=* USEBACKQ" %%F IN (`npm root -g`) DO (
-        SET basedir=%%F\devspace
-      )
+      SET basedir=%~dp0\node_modules\devspace
 
       IF NOT EXIST "!basedir!\!indexFile!" (
-        FOR /F "tokens=* USEBACKQ" %%F IN (`yarn global dir`) DO (
-          SET basedir=%%F\node_modules\devspace
+        FOR /F "tokens=* USEBACKQ" %%F IN (`npm root -g`) DO (
+          SET basedir=%%F\devspace
         )
 
         IF NOT EXIST "!basedir!\!indexFile!" (
-          echo Unable to find global npm/yarn dir
-          exit /b 1
+          FOR /F "tokens=* USEBACKQ" %%F IN (`yarn global dir`) DO (
+            SET basedir=%%F\node_modules\devspace
+          )
+
+          IF NOT EXIST "!basedir!\!indexFile!" (
+            echo Unable to find global npm/yarn dir
+            exit /b 1
+          )
         )
       )
     )

--- a/dist/npm/index.js
+++ b/dist/npm/index.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 const fs = require("fs");
+const https = require("https");
 const path = require("path");
 const execSync = require("child_process").execSync;
-const fetch = require("node-fetch");
-const Spinner = require("cli-spinner").Spinner;
-const inquirer = require('inquirer');
-const findProcess = require('find-process');
+
+const getSpinner = () => require("cli-spinner").Spinner;
+const getInquirer = () => require("inquirer");
+const getFindProcess = () => require("find-process");
 
 const downloadPathTemplate =
   "https://github.com/devspace-sh/devspace/releases/download/v{{version}}/devspace-{{platform}}-{{arch}}";
@@ -80,43 +81,91 @@ const sanitizeVersion = function(version) {
 
 const getLatestVersion = function (callback) {
   const releasesURL = "https://github.com/devspace-sh/devspace/releases/latest";
+  https.get(releasesURL, { headers: requestHeaders }, function (res) {
+    const redirectUrl = res.headers.location;
+    const matches = redirectUrl && /\/tag\/(.*)$/.exec(redirectUrl);
 
-  fetch(releasesURL, { headers: requestHeaders, redirect: false })
-    .then(function (res) {
-      if (!res.ok) {
-        console.error(
-          "Error requesting URL " +
-          releasesURL +
-          " (Status Code: " +
-          res.status +
-          ")"
-        );
-        process.exit(1);
-      }
-
-      const redirectUrl = res.url
-      if (redirectUrl == null) {
-        throw new Error('Error fetching latest version')
-      }
-
-      const matches = /\/tag\/(.*)$/.exec(redirectUrl)
-      if (!matches || matches.length !== 2) {
-        throw new Error('Error fetching latest version')
-      }
-
-      const latestVersion = matches[1].replace('v', '')
-      if (latestVersion) {
-        callback(latestVersion);
-      } else {
-        console.error("Unable to identify latest devspace version");
-        process.exit(2);
-      }
-    })
-    .catch(function (err) {
+    if (!matches || matches.length !== 2) {
       console.error("Error requesting URL " + releasesURL);
-      console.error(err)
       process.exit(1);
-    })
+    }
+
+    const latestVersion = matches[1].replace('v', '')
+    if (latestVersion) {
+      callback(latestVersion);
+    } else {
+      console.error("Unable to identify latest devspace version");
+      process.exit(2);
+    }
+  }).on("error", function (err) {
+    console.error("Error requesting URL " + releasesURL);
+    console.error(err)
+    process.exit(1);
+  })
+};
+
+const createSpinner = function (text) {
+  try {
+    const Spinner = getSpinner();
+    const spinner = new Spinner("%s " + text);
+    spinner.setSpinnerString("|/-\\");
+    return spinner;
+  } catch (err) {
+    return {
+      start: function () {
+        console.log(text);
+      },
+      stop: function () { }
+    };
+  }
+};
+
+const downloadFile = function (downloadPath, destination, callback) {
+  let done = false;
+  const finish = function (err, res) {
+    if (done) {
+      return;
+    }
+
+    done = true;
+    callback(err, res);
+  };
+
+  https.get(downloadPath, { headers: requestHeaders }, function (res) {
+    if (
+      res.statusCode &&
+      res.statusCode >= 300 &&
+      res.statusCode < 400 &&
+      res.headers.location
+    ) {
+      res.resume();
+      downloadFile(res.headers.location, destination, callback);
+      return;
+    }
+
+    if (res.statusCode !== 200) {
+      finish(null, res);
+      return;
+    }
+
+    const writeStream = fs.createWriteStream(destination)
+      .on("error", function (err) {
+        finish(err);
+      })
+      .on("finish", function () {
+        writeStream.close(function () {
+          finish(null, res);
+        });
+      });
+
+    res.on("error", function (err) {
+      finish(err);
+    });
+
+    res.pipe(writeStream);
+  }).on("error", function (err) {
+    finish(err);
+  });
 };
 
 if (action === "update-version") {
@@ -311,6 +360,7 @@ let continueProcess = function (askRemoveGlobalFolder) {
     removeScripts(true);
 
     if (askRemoveGlobalFolder && process.stdout.isTTY) {
+      const inquirer = getInquirer();
       let removeGlobalFolder = function () {
         try {
           let homedir = require('os').homedir();
@@ -377,33 +427,34 @@ let continueProcess = function (askRemoveGlobalFolder) {
 
         console.log("Download DevSpace CLI release: " + downloadPath + "\n");
 
-        const spinner = new Spinner(
-          "%s Downloading DevSpace CLI... (this may take a minute)"
+        const spinner = createSpinner(
+          "Downloading DevSpace CLI... (this may take a minute)"
         );
-        spinner.setSpinnerString("|/-\\");
         spinner.start();
 
-        let writeStream = fs
-          .createWriteStream(binaryPath + downloadExtension)
-          .on("error", function (err) {
-            spinner.stop(true);
-            console.error("Unable to write stream: " + err)
-            showRootError(version);
-          });
-
-        fetch(downloadPath, { headers: requestHeaders, encoding: null })
-          .catch(function (err) {
-            writeStream.end();
-            spinner.stop(true);
-            console.error("Error requesting URL: " + downloadPath);
-            process.exit(6);
-          })
-          .then(function (res) {
-            if (!res.ok) {
-              writeStream.end();
+        downloadFile(
+          downloadPath,
+          binaryPath + downloadExtension,
+          function (err, res) {
+            if (err) {
               spinner.stop(true);
 
-              if (res.status === 404) {
+              if (err.code === "EACCES" || err.code === "EPERM") {
+                console.error("Unable to write stream: " + err)
+                showRootError(version);
+                return;
+              }
+
+              console.error("Error requesting URL: " + downloadPath);
+              console.error(err);
+              process.exit(6);
+            }
+
+            if (!res || res.statusCode !== 200) {
+              spinner.stop(true);
+
+              if (res && res.statusCode === 404) {
+                res.resume();
                 console.error("Release version " + version + " not found.\n");
 
                 getLatestVersion(function (latestVersion) {
@@ -418,46 +469,44 @@ let continueProcess = function (askRemoveGlobalFolder) {
                   }
                 });
               } else {
+                if (res) {
+                  res.resume();
+                }
+
                 console.error(
                   "Error requesting URL " +
                   downloadPath +
                   " (Status Code: " +
-                  res.status +
+                  (res && res.statusCode) +
                   ")"
                 );
-                console.error(res.statusText);
+                console.error(res && res.statusMessage);
                 process.exit(7);
               }
-            } else {
-              try {
-                res.body.pipe(writeStream)
-                  .on("close", function () {
-                    writeStream.end();
-                    spinner.stop(true);
 
-                    try {
-                      fs.chmodSync(binaryPath + downloadExtension, "0755");
-                    } catch (e) {
-                      console.error("Unable to chmod: " + e)
-                      showRootError(version);
-                    }
-
-                    try {
-                      fs.renameSync(binaryPath + downloadExtension, binaryPath);
-                    } catch (e) {
-                      console.log(e);
-                      console.error("\nRenaming release binary failed. Please copy file manually:\n from: " + binaryPath + downloadExtension + "\n to: " + binaryPath + "\n");
-                      process.exit(8);
-                    }
-
-                    removeScripts(true);
-                  });
-              } catch (e) {
-                console.error("Unable to write stream: " + e)
-                showRootError(version);
-              }
+              return;
             }
-          });
+
+            spinner.stop(true);
+
+            try {
+              fs.chmodSync(binaryPath + downloadExtension, "0755");
+            } catch (e) {
+              console.error("Unable to chmod: " + e)
+              showRootError(version);
+            }
+
+            try {
+              fs.renameSync(binaryPath + downloadExtension, binaryPath);
+            } catch (e) {
+              console.log(e);
+              console.error("\nRenaming release binary failed. Please copy file manually:\n from: " + binaryPath + downloadExtension + "\n to: " + binaryPath + "\n");
+              process.exit(8);
+            }
+
+            removeScripts(true);
+          }
+        );
       };
 
       downloadRelease(version);
@@ -466,25 +515,30 @@ let continueProcess = function (askRemoveGlobalFolder) {
 }
 
 if (process.ppid > 1) {
-  findProcess('pid', process.ppid)
-    .then(function (list) {
-      if (list.length === 1 && list[0].ppid > 1) {
-        findProcess('pid', list[0].ppid)
-          .then(function (list) {
-            if (list.length === 1 && /((npm-cli.js("|')\s+up(date)?)|(yarn.js("|')\s+(global\s+)?upgrade))\s+.*((\/)|(\\)|(\s))devspace((\/)|(\\)|(\s)|$)/.test(list[0].cmd)) {
-              continueProcess(false);
-            } else {
+  try {
+    const findProcess = getFindProcess();
+    findProcess('pid', process.ppid)
+      .then(function (list) {
+        if (list.length === 1 && list[0].ppid > 1) {
+          findProcess('pid', list[0].ppid)
+            .then(function (list) {
+              if (list.length === 1 && /((npm-cli.js("|')\s+up(date)?)|(yarn.js("|')\s+(global\s+)?upgrade))\s+.*((\/)|(\\)|(\s))devspace((\/)|(\\)|(\s)|$)/.test(list[0].cmd)) {
+                continueProcess(false);
+              } else {
+                continueProcess(true);
+              }
+            }, function () {
               continueProcess(true);
-            }
-          }, function () {
-            continueProcess(true);
-          })
-      } else {
+            })
+        } else {
+          continueProcess(true);
+        }
+      }, function () {
         continueProcess(true);
-      }
-    }, function () {
-      continueProcess(true);
-    })
+      })
+  } catch (e) {
+    continueProcess(true);
+  }
 } else {
   continueProcess(true);
 }

--- a/dist/npm/package.json
+++ b/dist/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "devspace",
-    "version": "6.1.1",
+    "version": "undefined",
     "description": "DevSpace CLI - the swiss-army knife for Kubernetes. DevSpace CLI accelerates developing, deploying and debugging applications with Docker and Kubernetes.",
     "bin": {
         "devspace": "bin/devspace"

--- a/e2e/framework/helper.go
+++ b/e2e/framework/helper.go
@@ -92,13 +92,13 @@ func ExpectRemoteFileContents(imageSelector string, namespace string, filePath s
 	ExpectNoErrorWithOffset(1, err)
 }
 
-func ExpectLocalCurlContents(urlString string, contents string) {
+func ExpectLocalCurlContains(urlString string, contents string) {
 	client := resty.New()
 	err := wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*2, true, func(_ context.Context) (done bool, err error) {
 		resp, _ := client.R().
 			EnableTrace().
 			Get(urlString)
-		return strings.TrimSpace(string(resp.Body())) == strings.TrimSpace(contents), nil
+		return strings.Contains(strings.TrimSpace(string(resp.Body())), strings.TrimSpace(contents)), nil
 	})
 	ExpectNoErrorWithOffset(1, err)
 }
@@ -118,7 +118,7 @@ func ExpectContainerNameAndImageEqual(namespace, deploymentName, containerImage,
 	ExpectNoErrorWithOffset(1, err)
 }
 
-func ExpectRemoteCurlContents(imageSelector string, namespace string, urlString string, contents string) {
+func ExpectRemoteCurlContains(imageSelector string, namespace string, urlString string, contents string) {
 	kubeClient, err := kube.NewKubeHelper()
 	ExpectNoErrorWithOffset(1, err)
 	err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*2, true, func(_ context.Context) (done bool, err error) {
@@ -126,7 +126,7 @@ func ExpectRemoteCurlContents(imageSelector string, namespace string, urlString 
 		if err != nil {
 			return false, nil
 		}
-		return strings.TrimSpace(out) == strings.TrimSpace(contents), nil
+		return strings.Contains(strings.TrimSpace(out), strings.TrimSpace(contents)), nil
 	})
 	ExpectNoErrorWithOffset(1, err)
 }

--- a/e2e/tests/build/build.go
+++ b/e2e/tests/build/build.go
@@ -246,14 +246,7 @@ var _ = DevSpaceDescribe("build", func() {
 		imageList, err := dockerClient.ImageList(ctx, image.ListOptions{})
 		framework.ExpectNoError(err)
 
-		for _, image := range imageList {
-			if len(image.RepoTags) > 0 && image.RepoTags[0] == "my-docker-username/helloworld-buildkit:latest" {
-				err = nil
-				break
-			} else {
-				err = errors.New("image not found")
-			}
-		}
+		err = ensureImagePresent(imageList, "my-docker-username/helloworld-buildkit:latest")
 		framework.ExpectNoError(err)
 
 		var stdout, stderr bytes.Buffer
@@ -290,14 +283,7 @@ var _ = DevSpaceDescribe("build", func() {
 		imageList, err := dockerClient.ImageList(ctx, image.ListOptions{})
 		framework.ExpectNoError(err)
 
-		for _, image := range imageList {
-			if len(image.RepoTags) > 0 && image.RepoTags[0] == "my-docker-username/helloworld-buildkit:latest" {
-				err = nil
-				break
-			} else {
-				err = errors.New("image not found")
-			}
-		}
+		err = ensureImagePresent(imageList, "my-docker-username/helloworld-buildkit:latest")
 		framework.ExpectNoError(err)
 	})
 
@@ -342,14 +328,7 @@ var _ = DevSpaceDescribe("build", func() {
 		imageList, err := dockerClient.ImageList(ctx, image.ListOptions{})
 		framework.ExpectNoError(err)
 
-		for _, image := range imageList {
-			if len(image.RepoTags) > 0 && image.RepoTags[0] == "my-docker-username/helloworld-custom-build:latest" {
-				err = nil
-				break
-			} else {
-				err = errors.New("image not found")
-			}
-		}
+		err = ensureImagePresent(imageList, "my-docker-username/helloworld-custom-build:latest")
 		framework.ExpectNoError(err)
 	})
 
@@ -377,14 +356,7 @@ var _ = DevSpaceDescribe("build", func() {
 		imageList, err := dockerClient.ImageList(ctx, image.ListOptions{})
 		framework.ExpectNoError(err)
 		imageName := "my-docker-username/helloworld-dockerignore:latest"
-		for _, image := range imageList {
-			if image.RepoTags[0] == imageName {
-				err = nil
-				break
-			} else {
-				err = errors.New("image not found")
-			}
-		}
+		err = ensureImagePresent(imageList, imageName)
 		framework.ExpectNoError(err)
 
 		resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
@@ -442,14 +414,7 @@ var _ = DevSpaceDescribe("build", func() {
 		imageList, err := dockerClient.ImageList(ctx, image.ListOptions{})
 		framework.ExpectNoError(err)
 		imageName := "my-docker-username/helloworld-dockerignore-rel-path:latest"
-		for _, image := range imageList {
-			if image.RepoTags[0] == imageName {
-				err = nil
-				break
-			} else {
-				err = errors.New("image not found")
-			}
-		}
+		err = ensureImagePresent(imageList, imageName)
 		framework.ExpectNoError(err)
 
 		resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
@@ -507,14 +472,7 @@ var _ = DevSpaceDescribe("build", func() {
 		imageList, err := dockerClient.ImageList(ctx, image.ListOptions{})
 		framework.ExpectNoError(err)
 		imageName := "my-docker-username/helloworld-dockerignore-context:latest"
-		for _, image := range imageList {
-			if image.RepoTags[0] == imageName {
-				err = nil
-				break
-			} else {
-				err = errors.New("image not found")
-			}
-		}
+		err = ensureImagePresent(imageList, imageName)
 		framework.ExpectNoError(err)
 
 		resp, err := dockerClient.ContainerCreate(ctx, &container.Config{
@@ -554,6 +512,18 @@ func stdoutContains(stdout, content string) error {
 		return nil
 	}
 	return fmt.Errorf("%s found in output", content)
+}
+
+func ensureImagePresent(imageList []image.Summary, imageName string) error {
+	for _, image := range imageList {
+		for _, repoTag := range image.RepoTags {
+			if repoTag == imageName {
+				return nil
+			}
+		}
+	}
+
+	return errors.New("image not found")
 }
 
 func stderrContains(stderr, content string) error {

--- a/e2e/tests/command/command.go
+++ b/e2e/tests/command/command.go
@@ -73,7 +73,7 @@ var _ = DevSpaceDescribe("command", func() {
 		framework.ExpectNoError(err)
 		defer framework.CleanupTempDir(initialDir, tempDir)
 
-		defer os.Unsetenv("KUBECONFIG")
+		defer os.Unsetenv("KUBECONFIG") //nolint:errcheck
 		err = os.Setenv("KUBECONFIG", filepath.Join(tempDir, "config"))
 		framework.ExpectNoError(err)
 

--- a/e2e/tests/config/config.go
+++ b/e2e/tests/config/config.go
@@ -432,8 +432,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "false")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "false")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -454,8 +454,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -534,10 +534,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "test123")
+		_ = os.Setenv("FOO", "test123")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("FOO")
+		_ = os.Unsetenv("FOO")
 
 		latestConfig := &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -556,10 +556,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "test")
+		_ = os.Setenv("FOO", "test")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("FOO")
+		_ = os.Unsetenv("FOO")
 
 		latestConfig = &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -634,10 +634,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "some test here")
+		_ = os.Setenv("FOO", "some test here")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("FOO")
+		_ = os.Unsetenv("FOO")
 
 		latestConfig := &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -656,10 +656,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "test")
+		_ = os.Setenv("FOO", "test")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("FOO")
+		_ = os.Unsetenv("FOO")
 
 		latestConfig = &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -734,10 +734,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "false")
+		_ = os.Setenv("FOO", "false")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("FOO")
+		_ = os.Unsetenv("FOO")
 
 		latestConfig := &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -756,10 +756,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "^the string begins with ^t and ends with $")
+		_ = os.Setenv("FOO", "^the string begins with ^t and ends with $")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("FOO")
+		_ = os.Unsetenv("FOO")
 
 		latestConfig = &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -834,10 +834,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "the best string")
+		_ = os.Setenv("FOO", "the best string")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("FOO")
+		_ = os.Unsetenv("FOO")
 
 		latestConfig := &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -856,10 +856,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "a test string")
+		_ = os.Setenv("FOO", "a test string")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("FOO")
+		_ = os.Unsetenv("FOO")
 
 		latestConfig = &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -956,8 +956,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1052,8 +1052,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1074,8 +1074,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("BAR", "true")
-		defer os.Unsetenv("BAR")
+		_ = os.Setenv("BAR", "true")
+		defer os.Unsetenv("BAR") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1193,8 +1193,8 @@ var _ = DevSpaceDescribe("config", func() {
 			Out:      configBuffer,
 			SkipInfo: true,
 		}
-		os.Setenv("FOO", "false")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "false")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1215,8 +1215,8 @@ var _ = DevSpaceDescribe("config", func() {
 			Out:      configBuffer,
 			SkipInfo: true,
 		}
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1237,8 +1237,8 @@ var _ = DevSpaceDescribe("config", func() {
 			Out:      configBuffer,
 			SkipInfo: true,
 		}
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1286,10 +1286,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "true")
+		_ = os.Setenv("FOO", "true")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("FOO")
+		_ = os.Unsetenv("FOO")
 
 		latestConfig = &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -1310,10 +1310,10 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("BAR", "true")
+		_ = os.Setenv("BAR", "true")
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
-		os.Unsetenv("BAR")
+		_ = os.Unsetenv("BAR")
 
 		latestConfig = &latest.Config{}
 		err = yaml.Unmarshal(configBuffer.Bytes(), latestConfig)
@@ -1431,8 +1431,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1531,8 +1531,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
@@ -1584,8 +1584,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1637,8 +1637,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("BAR", "true")
-		defer os.Unsetenv("BAR")
+		_ = os.Setenv("BAR", "true")
+		defer os.Unsetenv("BAR") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1689,8 +1689,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("BAR", "true")
-		defer os.Unsetenv("BAR")
+		_ = os.Setenv("BAR", "true")
+		defer os.Unsetenv("BAR") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1742,8 +1742,8 @@ var _ = DevSpaceDescribe("config", func() {
 			SkipInfo: true,
 		}
 
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 
@@ -1775,8 +1775,8 @@ var _ = DevSpaceDescribe("config", func() {
 		}
 
 		// run with environment variable set.
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		err = printCmd.Run(f)
 		framework.ExpectNoError(err)
 

--- a/e2e/tests/dependencies/dependencies.go
+++ b/e2e/tests/dependencies/dependencies.go
@@ -229,8 +229,8 @@ dep2dep2wait
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		os.Setenv("DEP1_NAMESPACE", depNamespace)
-		defer os.Unsetenv("DEP1_NAMESPACE")
+		_ = os.Setenv("DEP1_NAMESPACE", depNamespace)
+		defer os.Unsetenv("DEP1_NAMESPACE") //nolint:errcheck
 		devCmd := &cmd.RunPipelineCmd{
 			GlobalFlags: &flags.GlobalFlags{
 				NoWarn:    true,
@@ -405,8 +405,8 @@ dep2dep2wait
 		defer framework.CleanupTempDir(initialDir, tempDir)
 
 		// load it from the regular path first
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		config, dependencies, err := framework.LoadConfig(f, kubeClient.Client(), filepath.Join(tempDir, "activated.yaml"))
 		framework.ExpectNoError(err)
 
@@ -423,8 +423,8 @@ dep2dep2wait
 		defer framework.CleanupTempDir(initialDir, tempDir)
 
 		// load activated dependencies with --disable-profile-activation
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		_, dependencies, err := framework.LoadConfigWithOptions(f, kubeClient.Client(), filepath.Join(tempDir, "activated.yaml"), &loader.ConfigOptions{
 			DisableProfileActivation: true,
 		})
@@ -442,8 +442,8 @@ dep2dep2wait
 		defer framework.CleanupTempDir(initialDir, tempDir)
 
 		// load it from the regular path first
-		os.Setenv("FOO", "true")
-		defer os.Unsetenv("FOO")
+		_ = os.Setenv("FOO", "true")
+		defer os.Unsetenv("FOO") //nolint:errcheck
 		_, dependencies, err := framework.LoadConfig(f, kubeClient.Client(), filepath.Join(tempDir, "deactivated.yaml"))
 		framework.ExpectNoError(err)
 
@@ -586,8 +586,8 @@ dep2dep2wait
 		framework.ExpectNoError(err)
 		defer framework.ExpectDeleteNamespace(kubeClient, ns)
 
-		os.Setenv("DEP1_DISABLED", "true")
-		defer os.Unsetenv("DEP1_DISABLED")
+		_ = os.Setenv("DEP1_DISABLED", "true")
+		defer os.Unsetenv("DEP1_DISABLED") //nolint:errcheck
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		devCmd := &cmd.RunPipelineCmd{
@@ -611,8 +611,8 @@ dep2dep2wait
 		framework.ExpectNoError(err)
 		defer framework.ExpectDeleteNamespace(kubeClient, ns)
 
-		os.Setenv("DEP1_DISABLED", "true")
-		defer os.Unsetenv("DEP1_DISABLED")
+		_ = os.Setenv("DEP1_DISABLED", "true")
+		defer os.Unsetenv("DEP1_DISABLED") //nolint:errcheck
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		devCmd := &cmd.RunPipelineCmd{
@@ -637,8 +637,8 @@ dep2dep2wait
 		framework.ExpectNoError(err)
 		defer framework.ExpectDeleteNamespace(kubeClient, ns)
 
-		os.Setenv("DEP1_DISABLED", "true")
-		defer os.Unsetenv("DEP1_DISABLED")
+		_ = os.Setenv("DEP1_DISABLED", "true")
+		defer os.Unsetenv("DEP1_DISABLED") //nolint:errcheck
 		cancelCtx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 

--- a/e2e/tests/pipelines/pipelines.go
+++ b/e2e/tests/pipelines/pipelines.go
@@ -563,9 +563,9 @@ var _ = DevSpaceDescribe("pipelines", func() {
 		defer framework.CleanupTempDir(initialDir, tempDir)
 
 		origEnv := os.Getenv("KUBE_CONFIG")
-		defer os.Setenv("KUBE_CONFIG", origEnv)
+		defer os.Setenv("KUBE_CONFIG", origEnv) //nolint:errcheck
 
-		os.Setenv("KUBE_CONFIG", "nonexistent.yaml")
+		_ = os.Setenv("KUBE_CONFIG", "nonexistent.yaml")
 		newEnv := os.Getenv("KUBE_CONFIG")
 		framework.ExpectEqual(newEnv, "nonexistent.yaml")
 

--- a/e2e/tests/portforward/portforward.go
+++ b/e2e/tests/portforward/portforward.go
@@ -3,14 +3,15 @@ package portforward
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+
 	"github.com/loft-sh/devspace/cmd"
 	"github.com/loft-sh/devspace/cmd/flags"
 	"github.com/loft-sh/devspace/e2e/framework"
 	"github.com/loft-sh/devspace/e2e/kube"
 	"github.com/loft-sh/devspace/pkg/util/factory"
 	"github.com/onsi/ginkgo/v2"
-	"net/http"
-	"os"
 )
 
 var _ = DevSpaceDescribe("portforward", func() {
@@ -69,13 +70,13 @@ var _ = DevSpaceDescribe("portforward", func() {
 			done <- devCmd.RunDefault(f)
 		}()
 
-		nginxResp := "<!DOCTYPE html>\n<html>\n<head>\n<title>Welcome to nginx!</title>\n<style>\nhtml { color-scheme: light dark; }\nbody { width: 35em; margin: 0 auto;\nfont-family: Tahoma, Verdana, Arial, sans-serif; }\n</style>\n</head>\n<body>\n<h1>Welcome to nginx!</h1>\n<p>If you see this page, the nginx web server is successfully installed and\nworking. Further configuration is required.</p>\n\n<p>For online documentation and support please refer to\n<a href=\"http://nginx.org/\">nginx.org</a>.<br/>\nCommercial support is available at\n<a href=\"http://nginx.com/\">nginx.com</a>.</p>\n\n<p><em>Thank you for using nginx.</em></p>\n</body>\n</html>"
-		framework.ExpectRemoteCurlContents("nginx", ns, "localhost", nginxResp)
-		framework.ExpectLocalCurlContents("http://localhost:3000", nginxResp)
+		nginxResp := "Welcome to nginx!"
+		framework.ExpectRemoteCurlContains("nginx", ns, "localhost", nginxResp)
+		framework.ExpectLocalCurlContains("http://localhost:3000", nginxResp)
 
 		httpServerResp := "Hello World!"
-		framework.ExpectLocalCurlContents("http://localhost:8888", httpServerResp)
-		framework.ExpectRemoteCurlContents("nginx", ns, "localhost:8888", httpServerResp)
+		framework.ExpectLocalCurlContains("http://localhost:8888", httpServerResp)
+		framework.ExpectRemoteCurlContains("nginx", ns, "localhost:8888", httpServerResp)
 
 		cancel()
 		err = <-done

--- a/e2e/tests/restarthelper/restarthelper.go
+++ b/e2e/tests/restarthelper/restarthelper.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -19,6 +20,16 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
+
+// writeUniqueBuildMarker ensures the test image is unique per run so it does not reuse an already-cached node image ID
+func writeUniqueBuildMarker(tempDir string) {
+	err := os.WriteFile(
+		filepath.Join(tempDir, ".devspace-e2e-build-marker"),
+		[]byte(time.Now().Format(time.RFC3339Nano)),
+		0644,
+	)
+	framework.ExpectNoError(err)
+}
 
 var _ = DevSpaceDescribe("restarthelper", func() {
 	initialDir, err := os.Getwd()
@@ -44,6 +55,7 @@ var _ = DevSpaceDescribe("restarthelper", func() {
 		tempDir, err := framework.CopyToTempDir("tests/restarthelper/testdata/v5")
 		framework.ExpectNoError(err)
 		defer framework.CleanupTempDir(initialDir, tempDir)
+		writeUniqueBuildMarker(tempDir)
 
 		ns, err := kubeClient.CreateNamespace("restarthelper")
 		framework.ExpectNoError(err)
@@ -125,6 +137,7 @@ var _ = DevSpaceDescribe("restarthelper", func() {
 		tempDir, err := framework.CopyToTempDir("tests/restarthelper/testdata/v6")
 		framework.ExpectNoError(err)
 		defer framework.CleanupTempDir(initialDir, tempDir)
+		writeUniqueBuildMarker(tempDir)
 
 		ns, err := kubeClient.CreateNamespace("restarthelper")
 		framework.ExpectNoError(err)
@@ -206,6 +219,7 @@ var _ = DevSpaceDescribe("restarthelper", func() {
 		tempDir, err := framework.CopyToTempDir("tests/restarthelper/testdata/v6-inject-restart-helper")
 		framework.ExpectNoError(err)
 		defer framework.CleanupTempDir(initialDir, tempDir)
+		writeUniqueBuildMarker(tempDir)
 
 		ns, err := kubeClient.CreateNamespace("restarthelper")
 		framework.ExpectNoError(err)
@@ -296,6 +310,7 @@ var _ = DevSpaceDescribe("restarthelper", func() {
 		tempDir, err := framework.CopyToTempDir("tests/restarthelper/testdata/v6-manual-start")
 		framework.ExpectNoError(err)
 		defer framework.CleanupTempDir(initialDir, tempDir)
+		writeUniqueBuildMarker(tempDir)
 
 		ns, err := kubeClient.CreateNamespace("restarthelper")
 		framework.ExpectNoError(err)

--- a/e2e/tests/restarthelper/testdata/v5/Dockerfile
+++ b/e2e/tests/restarthelper/testdata/v5/Dockerfile
@@ -1,2 +1,3 @@
 FROM alpine
+COPY .devspace-e2e-build-marker /.devspace-e2e-build-marker
 CMD ["sh", "-c" , "echo 'Started with legacy restart helper' && tail -f /dev/null"]

--- a/e2e/tests/restarthelper/testdata/v6-inject-restart-helper/Dockerfile
+++ b/e2e/tests/restarthelper/testdata/v6-inject-restart-helper/Dockerfile
@@ -1,2 +1,3 @@
 FROM alpine
+COPY .devspace-e2e-build-marker /.devspace-e2e-build-marker
 CMD ["sh", "-c" , "echo 'Started with legacy restart helper' && tail -f /dev/null"]

--- a/e2e/tests/restarthelper/testdata/v6-manual-start/Dockerfile
+++ b/e2e/tests/restarthelper/testdata/v6-manual-start/Dockerfile
@@ -1,2 +1,3 @@
 FROM alpine
+COPY .devspace-e2e-build-marker /.devspace-e2e-build-marker
 CMD ["sh", "-c" , "echo 'Started manually' && tail -f /dev/null"]

--- a/e2e/tests/restarthelper/testdata/v6/Dockerfile
+++ b/e2e/tests/restarthelper/testdata/v6/Dockerfile
@@ -1,2 +1,3 @@
 FROM alpine
+COPY .devspace-e2e-build-marker /.devspace-e2e-build-marker
 CMD ["tail", "-f", "/dev/null"]

--- a/e2e/tests/sync/sync.go
+++ b/e2e/tests/sync/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -834,11 +835,23 @@ var _ = DevSpaceDescribe("sync", func() {
 		// check that included file was not synced
 		framework.ExpectRemoteFileNotFound("alpine", ns, "/app/syncme/file.txt")
 
-		// write a file and check that it got synced
+		// Keep writing until the sync watcher observes a local change. This avoids
+		// racing the first write against watcher startup in slower CI environments.
 		payload := randutil.GenerateRandomString(10000)
-		err = os.WriteFile(filepath.Join(tempDir, "watching.txt"), []byte(payload), 0666)
+		err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*2, true, func(_ context.Context) (done bool, err error) {
+			err = os.WriteFile(filepath.Join(tempDir, "watching.txt"), []byte(payload), 0666)
+			if err != nil {
+				return false, err
+			}
+
+			out, err := kubeClient.ExecByImageSelector("alpine", ns, []string{"cat", "/app/watching.txt"})
+			if err != nil {
+				return false, nil
+			}
+
+			return strings.TrimSpace(out) == strings.TrimSpace(payload), nil
+		})
 		framework.ExpectNoError(err)
-		framework.ExpectRemoteFileContents("alpine", ns, "/app/watching.txt", payload)
 
 		// stop command
 		stop()

--- a/e2e/tests/terminal/terminal.go
+++ b/e2e/tests/terminal/terminal.go
@@ -100,7 +100,7 @@ sleep 1000000
 		framework.ExpectNoError(err)
 		defer framework.ExpectDeleteNamespace(kubeClient, ns)
 
-		buffer := &bytes.Buffer{}
+		buffer := &Buffer{}
 		devpod.DefaultTerminalStdout = buffer
 		devpod.DefaultTerminalStderr = buffer
 		devpod.DefaultTerminalStdin = nil
@@ -129,12 +129,10 @@ sleep 1000000
 		// wait until we get the first hostnames
 		var podName string
 		err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*3, true, func(_ context.Context) (done bool, err error) {
-			lines := strings.Split(buffer.String(), "\n")
-			if len(lines) <= 1 {
+			podName = lastTerminalPodName(buffer.String())
+			if podName == "" {
 				return false, nil
 			}
-
-			podName = strings.TrimSpace(lines[0])
 			return true, nil
 		})
 		framework.ExpectNoError(err)
@@ -169,12 +167,11 @@ sleep 1000000
 
 		// get new pod name
 		err = wait.PollUntilContextTimeout(context.TODO(), time.Second, time.Minute*3, true, func(_ context.Context) (done bool, err error) {
-			lines := strings.Split(buffer.String(), "\n")
-			if len(lines) <= 1 {
+			newPodName := lastTerminalPodName(buffer.String())
+			if newPodName == "" {
 				return false, nil
 			}
 
-			newPodName := strings.TrimSpace(lines[len(lines)-2])
 			if newPodName != podName {
 				podName = newPodName
 				return true, nil
@@ -239,4 +236,28 @@ func (s *Buffer) String() string {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	return s.buffer.String()
+}
+
+func lastTerminalPodName(output string) string {
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := sanitizeTerminalLine(lines[i])
+		if line != "" {
+			return line
+		}
+	}
+
+	return ""
+}
+
+func sanitizeTerminalLine(line string) string {
+	line = strings.Map(func(r rune) rune {
+		if r < 32 || r == 127 {
+			return -1
+		}
+
+		return r
+	}, line)
+
+	return strings.TrimSpace(line)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/loft-sh/devspace
 
-go 1.24
+go 1.25
 
-toolchain go1.24.4
+toolchain go1.25.9
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.2

--- a/hack/remove-system-helm.sh
+++ b/hack/remove-system-helm.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Remove any helm binary pre-installed by the runner so tests use devspace's bundled helm.
+while IFS= read -r h; do
+  rm -f "$h" 2>/dev/null
+  [ -e "$h" ] && PATH=$(tr ':' '\n' <<<"$PATH" | grep -vxF "$(dirname "$h")" | tr '\n' ':')
+done < <(type -aP helm 2>/dev/null | awk '!seen[$0]++')
+export PATH; hash -r 2>/dev/null || true

--- a/pkg/devspace/server/logs.go
+++ b/pkg/devspace/server/logs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -14,7 +15,18 @@ import (
 )
 
 var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin: func(r *http.Request) bool {
+		origin := r.Header.Get("Origin")
+		if origin == "" {
+			return true // non-browser clients (CLI tools, curl) send no Origin header
+		}
+		u, err := url.Parse(origin)
+		if err != nil {
+			return false
+		}
+		h := u.Hostname()
+		return h == "localhost" || h == "127.0.0.1"
+	},
 }
 
 type wsStream struct {

--- a/pkg/devspace/server/logs_test.go
+++ b/pkg/devspace/server/logs_test.go
@@ -1,0 +1,33 @@
+package server
+
+import (
+	"net/http"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestCheckOrigin(t *testing.T) {
+	cases := map[string]struct {
+		origin string
+		want   bool
+	}{
+		"no origin header (CLI/curl)": {origin: "", want: true},
+		"localhost origin":            {origin: "http://localhost:8080", want: true},
+		"127.0.0.1 origin":            {origin: "http://127.0.0.1:3000", want: true},
+		"localhost no port":           {origin: "http://localhost", want: true},
+		"external origin":             {origin: "http://bad.example.com", want: false},
+		"invalid origin":              {origin: "://bad-url", want: false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			r := &http.Request{Header: http.Header{}}
+			if tc.origin != "" {
+				r.Header.Set("Origin", tc.origin)
+			}
+			got := upgrader.CheckOrigin(r)
+			assert.Equal(t, tc.want, got, name)
+		})
+	}
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -133,6 +133,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
       "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -511,6 +512,7 @@
       "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "^0.2.36"
       },
@@ -3082,6 +3084,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.65.tgz",
       "integrity": "sha512-Guc3kE+W8LrQB9I3bF3blvNH15dXFIVIHIJTqrF8cp5XI/3IJcHGo4C3sJNPb8Zx49aofXKnAGIKyonE4f7XWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "^0.16",
@@ -3542,6 +3545,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5144,6 +5148,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha512-ITKNuq2wKlW1fJg9sSW52eepoYgZBggvOAHC0u/CYu/qxQ9EVzThCgR69BnSXLHjy2f7SY5zaQ4yt7H9ZVxY2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -5614,6 +5619,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -10675,6 +10681,7 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-24.9.0.tgz",
       "integrity": "sha512-YvkBL1Zm7d2B1+h5fHEOdyjCG+sGMz4f8D86/0HiqJ6MB4MnDc8FgP5vdWsGnemOQro7lnYo8UakZ3+5A0jxGw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "import-local": "^2.0.0",
         "jest-cli": "^24.9.0"
@@ -16572,6 +16579,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -17057,6 +17065,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
       "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -20940,6 +20949,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
       "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21862,6 +21872,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.38.0.tgz",
       "integrity": "sha512-lbuFsVOq8PZY+1Ytz/mYOvYOo+d4IJ31hHk/7iyoeWtwN33V+5HYotSH+UIb9tq914ey0Hot7z6HugD+je3sWw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.8.5",
         "@webassemblyjs/helper-module-context": "1.8.5",
@@ -21922,6 +21933,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22034,6 +22046,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -22725,6 +22738,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
       "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8.3.0"
       },


### PR DESCRIPTION
**What issue type does this pull request address?** (keep at least one, remove the others) 
/kind bugfix

**What does this pull request do? Which issues does it resolve?** (use `resolves #<issue_number>` if possible) 
resolves #DSP-176


**Please provide a short message that should be published in the DevSpace release notes**
See: https://github.com/devspace-sh/devspace/security/advisories/GHSA-hqwm-7x7x-8379


**What else do we need to know?** 

The changes pertaining to the CVE are all to do with the websocket upgrader and logs, but ci was failing for a variety of reasons.  I kept it a several commits rather than forcing them all into one to make review easier.  The windows unit test failure is due to helm v4 already being on the runner, so it doesn't download v3 and the version string check fails.  I can add something to the workflow to remove the default installed helm so it will pass, but I figured we could also just leave that to a future PR.
