### PR TITLE
ci: update GitHub Actions workflow actions

### DIFF
--- a/.github/workflows/check-docs.yaml
+++ b/.github/workflows/check-docs.yaml
@@ -10,7 +10,7 @@ jobs:
     outputs:
       docs_changes: ${{ steps.check_file_changed.outputs.changed }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           # Checkout as many commits as needed for the diff
           fetch-depth: 2

--- a/.github/workflows/ui.yaml
+++ b/.github/workflows/ui.yaml
@@ -13,8 +13,8 @@ jobs:
   test-ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
       - name: Cache node modules


### PR DESCRIPTION
## Summary

Update GitHub Actions workflow dependencies in CI workflows.

## Changes

- Update `actions/checkout` from v3 to v6 in `check-docs.yaml`.
- Update `actions/checkout` from v1 to v6 in `ui.yaml`.
- Update `actions/setup-node` from v1 to v6 in `ui.yaml`.

## Validation

- Squashed the workflow updates into a single commit.
- Confirmed the branch is ahead of `main` by 1 commit.
- Confirmed the diff only includes:
  - `.github/workflows/check-docs.yaml`
  - `.github/workflows/ui.yaml`