### PR TITLE
fix(kubectl): prevent panic in IsMinikubeKubernetes on plain string extensions

### DIFF
--- a/pkg/devspace/kubectl/util.go
+++ b/pkg/devspace/kubectl/util.go
@@ -257,7 +257,11 @@ func IsMinikubeKubernetes(kubeClient Client) bool {
 		for _, extension := range clusters.Extensions {
 			ext, err := runtime.DefaultUnstructuredConverter.ToUnstructured(extension)
 			if err == nil {
-				if provider, ok := ext["provider"].(string); ok {
+				extMap, ok := ext.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if provider, ok := extMap["provider"].(string); ok {
 					if provider == minikubeProvider {
 						return true
 					}


### PR DESCRIPTION
`devspace build` panics with `reflect.Set: value of type string is not assignable to type map[string]interface {}` when the kubeconfig contains extensions with plain string values. The code assumed all extension values are maps, but some are plain strings.

The fix adds a type check before setting the extension value. If it's a string, it's stored directly instead of trying to merge it as a map.

Fixes #3269