### PR TITLE
fix: warn when config pre-loading times out and make the timeout configurable

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,9 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -65,6 +67,12 @@ func NewRootCmd(f factory.Factory) *cobra.Command {
 				log.SetLevel(logrus.FatalLevel)
 			} else if globalFlags.Debug {
 				log.SetLevel(logrus.DebugLevel)
+			}
+
+			// print log messages deferred during config pre-loading, now that the
+			// log level from the flags is known; skip them for shell completions
+			if cobraCmd.Name() != cobra.ShellCompRequestCmd && cobraCmd.Name() != cobra.ShellCompNoDescRequestCmd && cobraCmd.Name() != "completion" {
+				flushPreloadLogs(log)
 			}
 
 			ansi.DisableColors(globalFlags.NoColors)
@@ -159,6 +167,10 @@ func Execute() {
 			os.Exit(retCode.ExitCode)
 		}
 
+		// print any log messages deferred during config pre-loading, so e.g. an
+		// "unknown flag" error caused by a pre-load timeout is explained
+		flushPreloadLogs(f.GetLog())
+
 		// error hooks
 		pluginErr := hook.ExecuteHooks(nil, map[string]interface{}{"error": err}, "root.errorExecution", "command:error")
 		if pluginErr != nil {
@@ -200,8 +212,16 @@ func BuildRoot(f factory.Factory, excludePlugins bool) *cobra.Command {
 	if os.Getenv(expression.DevSpaceSkipPreloadEnv) == "" {
 		rawConfig, err = parseConfig(f)
 		if err != nil {
-			f.GetLog().Debugf("error parsing raw config: %v", err)
-		} else {
+			// defer the messages until the log level from the flags is known
+			var timeoutErr *preloadTimeoutError
+			if errors.As(err, &timeoutErr) {
+				deferPreloadLog(logrus.WarnLevel, timeoutErr.Error())
+				deferPreloadLog(logrus.DebugLevel, fmt.Sprintf("error pre-loading config: %v", timeoutErr.Unwrap()))
+			} else {
+				deferPreloadLog(logrus.DebugLevel, fmt.Sprintf("error parsing raw config: %v", err))
+			}
+		}
+		if rawConfig != nil {
 			env.GlobalGetEnv = rawConfig.GetEnv
 		}
 	}
@@ -318,6 +338,84 @@ func disableKlog() {
 	klogv2.SetOutput(io.Discard)
 }
 
+// DevSpacePreloadTimeoutEnv can be used to change the maximum time DevSpace waits
+// for pre-loading the config (e.g. resolving variables from commands) before
+// executing a command. Accepts a duration such as 30s or 1m as well as plain
+// seconds; 0 disables the timeout. Must be set in the process environment, as it
+// is read before .env files and config variables are loaded.
+const DevSpacePreloadTimeoutEnv = "DEVSPACE_PRELOAD_TIMEOUT"
+
+// defaultPreloadTimeout is the default timeout for pre-loading the config
+const defaultPreloadTimeout = time.Second * 10
+
+// preloadLogs collects log messages produced while pre-loading the config in
+// BuildRoot, which runs before cobra has parsed the log-level flags; they are
+// flushed once the final log level is known (or before a fatal error)
+type preloadLog struct {
+	level   logrus.Level
+	message string
+}
+
+var preloadLogs []preloadLog
+
+func deferPreloadLog(level logrus.Level, message string) {
+	preloadLogs = append(preloadLogs, preloadLog{level: level, message: message})
+}
+
+func flushPreloadLogs(logger log.Logger) {
+	for _, l := range preloadLogs {
+		if l.level == logrus.WarnLevel {
+			logger.Warnf("%s", l.message)
+		} else {
+			logger.Debugf("%s", l.message)
+		}
+	}
+	preloadLogs = nil
+}
+
+// preloadTimeoutError is returned by parseConfig if pre-loading the config was
+// cancelled because it took longer than the configured timeout
+type preloadTimeoutError struct {
+	timeout time.Duration
+	err     error
+}
+
+func (e *preloadTimeoutError) Error() string {
+	return fmt.Sprintf("pre-loading the config took longer than %s and was cancelled, which usually means resolving a variable or expression took too long. Custom commands, pipeline flags and variables defined in the config might be unavailable for this run. You can increase this timeout via the %s environment variable (0 disables it), e.g. %s=30s", e.timeout, DevSpacePreloadTimeoutEnv, DevSpacePreloadTimeoutEnv)
+}
+
+func (e *preloadTimeoutError) Unwrap() error {
+	return e.err
+}
+
+// preloadTimeout returns the timeout for pre-loading the config, 0 meaning no timeout
+func preloadTimeout() time.Duration {
+	value := os.Getenv(DevSpacePreloadTimeoutEnv)
+	if value == "" {
+		return defaultPreloadTimeout
+	}
+
+	timeout, err := time.ParseDuration(value)
+	if err != nil {
+		// also allow specifying plain seconds, e.g. DEVSPACE_PRELOAD_TIMEOUT=30
+		seconds, convErr := strconv.Atoi(value)
+		if convErr != nil {
+			deferPreloadLog(logrus.WarnLevel, fmt.Sprintf("Invalid value %q for %s, falling back to %s: %v", value, DevSpacePreloadTimeoutEnv, defaultPreloadTimeout, err))
+			return defaultPreloadTimeout
+		}
+		if int64(seconds) > math.MaxInt64/int64(time.Second) {
+			// converting to a duration would overflow; treat as no timeout
+			return 0
+		}
+		timeout = time.Duration(seconds) * time.Second
+	}
+	if timeout < 0 {
+		deferPreloadLog(logrus.WarnLevel, fmt.Sprintf("Invalid value %q for %s, falling back to %s: timeout must not be negative", value, DevSpacePreloadTimeoutEnv, defaultPreloadTimeout))
+		return defaultPreloadTimeout
+	}
+	return timeout
+}
+
 func parseConfig(f factory.Factory) (*RawConfig, error) {
 	// get current working dir
 	cwd, err := os.Getwd()
@@ -341,8 +439,13 @@ func parseConfig(f factory.Factory) (*RawConfig, error) {
 	}
 
 	// Parse commands
-	timeoutCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
-	defer cancel()
+	timeoutCtx := context.Background()
+	timeout := preloadTimeout()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		timeoutCtx, cancel = context.WithTimeout(timeoutCtx, timeout)
+		defer cancel()
+	}
 
 	r := &RawConfig{
 		resolved: map[string]string{},
@@ -350,6 +453,12 @@ func parseConfig(f factory.Factory) (*RawConfig, error) {
 	_, err = configLoader.LoadWithParser(timeoutCtx, nil, nil, r, &loader.ConfigOptions{
 		Dry: true,
 	}, log.Discard)
+	if err != nil && timeoutCtx.Err() != nil {
+		// pre-loading was cancelled by the timeout, so custom commands and pipeline
+		// flags from the config might be missing; return a dedicated error to avoid
+		// confusing follow-up errors such as "unknown flag"
+		return r, &preloadTimeoutError{timeout: timeout, err: err}
+	}
 	if r.Resolver != nil {
 		return r, nil
 	}
@@ -394,8 +503,9 @@ func (r *RawConfig) GetEnv(name string) string {
 		return value
 	}
 
-	// try to find devspace variable
-	if r.Resolver != nil {
+	// try to find devspace variable; skip the resolver if its context is already
+	// cancelled (e.g. after a pre-load timeout), as resolving could never succeed
+	if r.Resolver != nil && r.Ctx != nil && r.Ctx.Err() == nil {
 		r.resolvedMutex.Lock()
 		defer r.resolvedMutex.Unlock()
 

--- a/docs/pages/configuration/variables.mdx
+++ b/docs/pages/configuration/variables.mdx
@@ -73,6 +73,10 @@ vars:
     args: ["rev-parse", "HEAD"]
 ```
 
+:::warning Pre-Loading Timeout
+Before executing a command, DevSpace pre-loads the config (including resolving variables from commands) to make custom commands and pipeline flags available. This pre-loading is limited to 10 seconds by default. If resolving all variables takes longer than that, DevSpace prints a warning and custom commands and pipeline flags defined in the config will be unavailable for this run. You can change this timeout via the `DEVSPACE_PRELOAD_TIMEOUT` environment variable, e.g. `DEVSPACE_PRELOAD_TIMEOUT=30s` (plain seconds such as `30` also work, and `0` disables the timeout entirely). Note that `DEVSPACE_PRELOAD_TIMEOUT` must be set in the process environment: it is read before `.env` files (loaded via `DEVSPACE_ENV_FILE`) and config variables are processed, so setting it there has no effect.
+:::
+
 
 ### From User Input (Question)
 DevSpace can also ask the user to provide a value for a variable and you can provide a custom question and configure other input attributes for the question:


### PR DESCRIPTION
**What issue type does this pull request address?**
/kind bug

**What does this pull request do? Which issues does it resolve?**
Fixes #3213

Config pre-loading in `BuildRoot` (used to register custom commands and dynamic pipeline flags) is cancelled after a hardcoded 10s timeout. When variable resolution takes longer (e.g. secrets fetched via an external CLI in the `vars` block), the failure was swallowed entirely: `parseConfig` returned the partial config with a `nil` error, the dynamic pipeline flags were silently never registered, and the command later died with an unrelated `fatal unknown flag: --apps`.

This PR surfaces the timeout and makes it configurable:

- When pre-loading exceeds the timeout, DevSpace now prints a clear warning explaining that custom commands, pipeline flags and variables defined in the config might be unavailable for this run, and how to raise the timeout. On a fatal error such as `unknown flag`, the warning is printed right before the error so the failure is explained.
- The timeout can be changed via a new `DEVSPACE_PRELOAD_TIMEOUT` environment variable: a duration such as `30s`/`1m`, plain seconds such as `30`, or `0` to disable the timeout entirely (the plain-seconds path guards against `int64` overflow by treating overflowing values as "no timeout").
- Pre-load log messages are deferred until the log-level flags are parsed, so `--silent` suppresses the warning and shell completions (`__complete`) stay silent instead of emitting the warning on every TAB press.
- The underlying load error is preserved (`Unwrap`) and logged at debug level, so `--debug` reveals the real cause, e.g. `fill variable BLAH with command 'sleep 12 && …': context deadline exceeded` — previously it was discarded.
- `RawConfig.GetEnv` now skips the variable resolver when its context is already cancelled, avoiding doomed command executions (spawn + immediate kill) for every env lookup after a timeout.
- The pre-loading timeout is documented in the variables docs (`From Command` section), including the note that the variable must be set in the process environment because it is read before `.env` files are loaded.

**Please provide a short message that should be published in the DevSpace release notes**
Fixed an issue where slow variable resolution during config pre-loading caused confusing `unknown flag` errors; DevSpace now prints a clear warning and the timeout is configurable via `DEVSPACE_PRELOAD_TIMEOUT` (`0` disables it).

**What else do we need to know?**
Verified manually against the reproduction from #3213 (a `vars` command sleeping 12s plus a pipeline flag): the default run now prints the warning before `unknown flag: --apps`; with `DEVSPACE_PRELOAD_TIMEOUT=30s`, `=13` (plain seconds) or `=0` the flag is registered and parsed correctly; `--silent` suppresses the warning; `--debug` shows the underlying cause; invalid values (`abc`, negative) warn and fall back to the 10s default; fast configs behave exactly as before. `go test ./cmd`, `go vet` and `golangci-lint` (repo config) pass with no new issues.

One known limitation kept out of scope: when the timeout does fire, pipeline commands still hard-fail on their dynamic flags — cobra rejects them before `RunE`. A deeper fix would be adopting the `DisableFlagParsing` + late-registration pattern that `devspace run` already uses (which is why `devspace run` survives a pre-load timeout), but that requires refactoring the shared `RunPipelineCmd` plumbing and seems better suited for a follow-up. Happy to open an issue for it or take a stab in a separate PR if you agree with the direction.
