### PR TITLE
fix: close HTTP response bodies in helper requests

### DIFF
--- a/cmd/open.go
+++ b/cmd/open.go
@@ -258,11 +258,15 @@ func openURL(url string, kubectlClient kubectl.Client, analyzeNamespace string, 
 	for time.Since(now) < maxWait {
 		// Check if domain is ready => ignore error as we will retry request
 		resp, _ := http.Get(url)
-		if resp != nil && resp.StatusCode != http.StatusBadGateway && resp.StatusCode != http.StatusServiceUnavailable {
-			time.Sleep(time.Second * 1)
-			_ = open.Start(url)
-			log.Donef("Successfully opened %s", url)
-			return nil
+		if resp != nil {
+			statusCode := resp.StatusCode
+			_ = resp.Body.Close()
+			if statusCode != http.StatusBadGateway && statusCode != http.StatusServiceUnavailable {
+				time.Sleep(time.Second * 1)
+				_ = open.Start(url)
+				log.Donef("Successfully opened %s", url)
+				return nil
+			}
 		}
 
 		if kubectlClient != nil && analyzeNamespace != "" {

--- a/pkg/devspace/build/builder/restart/restart.go
+++ b/pkg/devspace/build/builder/restart/restart.go
@@ -183,6 +183,7 @@ func loadRestartHelper(path, defaultScript string) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		defer resp.Body.Close()
 
 		out, err := io.ReadAll(resp.Body)
 		if err != nil {


### PR DESCRIPTION
**What issue type does this pull request address?**

/kind bugfix

**What does this pull request do? Which issues does it resolve?**

Closes HTTP response bodies in the URL readiness polling loop and after downloading the restart helper. This prevents connections and file descriptors from being retained across retries. No associated issue.

**Please provide a short message that should be published in the DevSpace release notes**

Fixed an issue where repeated URL readiness checks and restart-helper downloads could retain HTTP resources.

**What else do we need to know?**

`go test ./pkg/devspace/build/builder/restart` passes. The changed `cmd` package was formatted with `gofmt`, and `git diff --check` passes.